### PR TITLE
feat: full BLISS1 support — climate control, sensors, sync profiles, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## ⚠️ Disclaimer
+## Disclaimer
 
 This project is not affiliated, associated, authorized, endorsed by, or in any way officially connected with Finder S.p.A.
 The Finder BLISS name, as well as related names, marks, emblems and images, are registered trademarks of their respective owners.
@@ -6,55 +6,107 @@ This integration is provided for **research and interoperability purposes only**
 Use it at your own risk.
 
 # Finder Bliss Thermostats (Home Assistant Custom Component)
-This is a Home Assistant custom component that provides sensor and climate entity support for **FINDER BLISS** thermostats (BLISS1, BLISS2) using the unofficial Python API, `pyFinderBliss`.
 
-It allows you to:
-* Monitor current temperature, humidity, battery level, and Wi-Fi signal.
-* Control the target temperature (setpoint).
-* Change the operating mode (HEAT/MANUAL, AUTO, OFF).
+A Home Assistant custom integration for **Finder BLISS** thermostats using the unofficial `pyFinderBliss` API client.
 
-**Note:** This integration is unofficial and is not related in any way to Finder. It was developed by reverse-engineering the requests made by the official app, and the API may stop working at any time if the provider makes changes.
+### Supported devices
 
----
-
-## 🚀 Installation (via HACS - Recommended)
-
-This integration can be installed easily using the Home Assistant Community Store (HACS).
-
-1.  **Open HACS** in your Home Assistant UI.
-2.  Go to the **Integrations** section.
-3.  Click the **three dots** in the top right corner and select **Custom repositories**.
-4.  Enter the URL of this repository: `https://github.com/condatek/finderblissha`
-5.  Select the **Category** as `Integration`.
-6.  Click **ADD**.
-7.  HACS will list the new repository. Search for **"Finder Bliss"** and click **Download**.
-8.  **Restart Home Assistant** to ensure the new component is loaded.
-
-## 🛠️ Configuration
-
-After restarting Home Assistant:
-
-1.  Go to **Settings** -> **Devices & Services** -> **Integrations**.
-2.  Click **ADD INTEGRATION**.
-3.  Search for **"Finder Bliss"**.
-4.  Enter your **Finder Bliss App Credentials** (Username/Email and Password).
-5.  The integration will validate the credentials, fetch your devices, and create the corresponding `climate` and `sensor` entities.
-
-## 💻 Manual Installation (Not Recommended)
-
-1.  Download the contents of this repository.
-2.  Copy the entire `finderblissha` folder into your Home Assistant's `custom_components` directory.
-    * *Example Path: `/config/custom_components/finderblissha/`*
-3.  Restart Home Assistant.
-4.  Follow the configuration steps above (Settings -> Devices & Services -> Add Integration).
+| Model | Tag | Tested |
+|---|---|---|
+| Bliss WiFi Next (1C.91) | BLISS1 | Yes |
+| Bliss 2 | BLISS2 | Partial |
 
 ---
 
-## 👨‍💻 Contributing
+## Features
 
-Contributions to this project are welcome! If you'd like to help develop features or improve functionality, please fork the repository and create a pull request.
+### Climate entity
 
-**TODOs:**
-* Optimize the WebSocket connection for real-time updates.
-* Add support for specific device features (e.g., specific schedule modes).
-* Improve error handling and extend test coverage.
+- **Current & target temperature** monitoring and control
+- **HVAC modes**: Off (frost protection), Heat, Cool, Auto
+- **Heating / Cooling** — switching between Heat and Cool automatically changes the device season (Winter/Summer)
+- **HVAC action** — shows Heating, Cooling, or Idle based on the relay status
+- **Schedule presets** — select named schedule programs configured in the Finder Bliss app (e.g. "Estate", "Freddo PT")
+
+### Sensors
+
+| Sensor | Device class | Unit | Category |
+|---|---|---|---|
+| Temperature | `temperature` | °C | — |
+| Humidity | `humidity` | % | — |
+| Battery | `battery` | % | Diagnostic |
+| WiFi level | `signal_strength` | dBm | Diagnostic |
+| Mode | — | — | Diagnostic |
+| Set point | `temperature` | °C | — |
+| Manual set point | `temperature` | °C | — |
+| Season | — | — | Diagnostic |
+| Thermal differential | `temperature` | °C | Diagnostic |
+| Schedule | — | — | — |
+
+The **Schedule** sensor shows the active preset name as its state and exposes per-day time blocks as attributes (e.g. `Monday: ["06:00-20:00: 19.0°C", "20:00-24:00: 18.0°C"]`).
+
+Battery percentage is calibrated for 4xAA batteries in a 2S2P configuration (2.1V–3.0V range).
+
+### Sync profile (select entity)
+
+An editable select entity to control the device's cloud sync interval:
+
+| Profile | Interval |
+|---|---|
+| Energy saving | 10 min |
+| Normal | 5 min |
+| Fast | 2 min |
+| Super fast | 1 min |
+
+Categorized as a **Config** entity.
+
+### Credential management
+
+- **Reconfigure** — update username/password from the integration's settings page (three-dot menu)
+- **Reauth** — if credentials become invalid, Home Assistant automatically prompts for new ones
+
+---
+
+## Installation (via HACS)
+
+1. Open **HACS** in your Home Assistant UI.
+2. Go to **Integrations**.
+3. Click the three dots in the top right and select **Custom repositories**.
+4. Enter the repository URL: `https://github.com/marl1w/finderblissha`
+5. Select category **Integration** and click **ADD**.
+6. Search for **"Finder Bliss"** and click **Download**.
+7. **Restart Home Assistant**.
+
+## Configuration
+
+1. Go to **Settings > Devices & Services > Integrations**.
+2. Click **ADD INTEGRATION**.
+3. Search for **"Finder Bliss Thermostats"**.
+4. Enter your Finder Bliss app credentials (email and password).
+5. The integration validates the credentials and creates climate, sensor, and select entities for each thermostat.
+
+To update credentials later, go to the integration entry, click the three-dot menu, and select **Reconfigure**.
+
+## Manual Installation
+
+1. Download the contents of this repository.
+2. Copy the `finderblissha` folder into your Home Assistant `custom_components` directory (e.g. `/config/custom_components/finderblissha/`).
+3. Restart Home Assistant.
+4. Follow the configuration steps above.
+
+---
+
+## Notes
+
+- The integration communicates via the Finder Bliss cloud API (OAuth2 + SignalR WebSocket). It does **not** use local/Bluetooth communication.
+- **Off mode** on BLISS1 devices activates frost protection (anti-freeze), not a full power-off.
+- Thermal differential (hysteresis) is exposed as a read-only diagnostic sensor. It can be configured from the Finder Bliss app.
+- The API is unofficial and may break if Finder changes their cloud service.
+
+## Acknowledgements
+
+This project is a fork of [condatek/finderblissha](https://github.com/condatek/finderblissha), the original Finder Bliss Home Assistant integration.
+
+## Contributing
+
+Contributions are welcome. Fork the repository and open a pull request.

--- a/custom_components/finderblissha/__init__.py
+++ b/custom_components/finderblissha/__init__.py
@@ -1,10 +1,14 @@
+"""The Finder Bliss Thermostats integration."""
+
+from __future__ import annotations
+
 from datetime import timedelta
 import logging
 
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.config_entries import ConfigEntry # Import necessario per il tipaggio
+from homeassistant.config_entries import ConfigEntry
 
 from .const import DOMAIN, PLATFORMS, DEFAULT_SCAN_INTERVAL
 from .pyfinderbliss.pyfinderbliss_wrapper import PyFinderBlissAPI
@@ -13,21 +17,27 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Finder Bliss from a config entry."""
-    # Assicura che esista il dizionario principale per il DOMAIN
     hass.data.setdefault(DOMAIN, {})
-    
-    # 1. Setup API
-    # Usiamo entry.data per le credenziali (memorizzate nella configurazione)
+
     api = PyFinderBlissAPI(entry.data["username"], entry.data["password"])
-    # NOTA: Assicurati che entry.data contenga "username" e "password"
-    await api.async_setup()
-    
-    # 2. Setup Coordinator
+    try:
+        await api.async_setup()
+    except Exception as err:
+        err_msg = str(err).lower()
+        if "invalid" in err_msg or "unauthorized" in err_msg or "401" in err_msg:
+            raise ConfigEntryAuthFailed("Invalid credentials") from err
+        raise ConfigEntryNotReady(f"Cannot connect: {err}") from err
+
     async def async_update_data():
-        """Fetch data from API."""
-        return await api.async_get_devices()
+        try:
+            return await api.async_get_devices()
+        except Exception as err:
+            err_msg = str(err).lower()
+            if "invalid" in err_msg or "unauthorized" in err_msg or "401" in err_msg:
+                raise ConfigEntryAuthFailed("Invalid credentials") from err
+            raise
 
     coordinator = DataUpdateCoordinator(
         hass,
@@ -36,34 +46,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         update_method=async_update_data,
         update_interval=SCAN_INTERVAL,
     )
-    
-    # Esegue il primo aggiornamento per popolare coordinator.data
+
     await coordinator.async_config_entry_first_refresh()
 
-    # 3. Memorizza API e Coordinator in hass.data[DOMAIN][entry.entry_id]
-    # QUESTA È LA MODIFICA CHIAVE che risolve il KeyError in climate.py
     hass.data[DOMAIN][entry.entry_id] = {
         "api": api,
         "coordinator": coordinator,
     }
 
-    # 4. Inoltra la configurazione a tutte le piattaforme (sensor, climate, ecc.)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    
-    # 1. Scarica le piattaforme (climate, sensor, ecc.)
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    
+
     if unload_ok:
-        # 2. Rimuove i dati specifici di questa configurazione
-        hass.data[DOMAIN].pop(entry.entry_id)
-        
-        # 3. Pulisce la chiave principale DOMAIN se non ci sono altre configurazioni
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id)
+        api: PyFinderBlissAPI = entry_data["api"]
+        await api.async_close()
+
         if not hass.data[DOMAIN]:
             hass.data.pop(DOMAIN)
-            
+
     return unload_ok

--- a/custom_components/finderblissha/climate.py
+++ b/custom_components/finderblissha/climate.py
@@ -2,252 +2,297 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
-from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
-    DataUpdateCoordinator,
     CoordinatorEntity,
+    DataUpdateCoordinator,
 )
-from homeassistant.config_entries import ConfigEntry 
 
 from .const import DOMAIN
-from .pyfinderbliss.pyfinderbliss_wrapper import PyFinderBlissAPI, BlissDevice
+from .pyfinderbliss.pyfinderbliss_wrapper import BlissDevice, PyFinderBlissAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-# --- Mode Mapping ---
-HA_TO_BLISS_MODE = {
-    HVACMode.HEAT: "MANUAL",
-    HVACMode.AUTO: "AUTO",
-    HVACMode.OFF: "OFF",
-}
 
-BLISS_TO_HA_MODE = {v: k for k, v in HA_TO_BLISS_MODE.items()}
-
-SUPPORTED_HA_MODES = list(HA_TO_BLISS_MODE.keys())
+def _normalize_schedule_days(days: list) -> list:
+    """Normalize schedule days for reliable comparison."""
+    normalized = []
+    for day_entry in sorted(days, key=lambda d: d.get("day", 0)):
+        set_points = sorted(
+            day_entry.get("setPoints", []),
+            key=lambda sp: (sp.get("hour", 0), sp.get("minute", 0))
+        )
+        normalized.append({
+            "day": day_entry.get("day"),
+            "setPoints": [
+                {"hour": sp.get("hour"), "minute": sp.get("minute"), "setPoint": sp.get("setPoint")}
+                for sp in set_points
+            ]
+        })
+    return normalized
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the climate platform from a config entry."""
-    
     entry_data = hass.data[DOMAIN][entry.entry_id]
-
     coordinator: DataUpdateCoordinator = entry_data["coordinator"]
     api: PyFinderBlissAPI = entry_data["api"]
 
     entities = []
-    # Coordinator.data holds the list of BlissDevice objects after the API call
     for device in coordinator.data:
         if not isinstance(device, BlissDevice):
             continue
-        
-        # Only add a climate entity if the device reports a set point
-        if getattr(device, "set_point", None) is not None:
-            _LOGGER.debug(f"Adding climate entity for device: {device.name}")
+        if getattr(device, "temperature", None) not in (None, "N/A"):
             entities.append(FinderBlissClimate(coordinator, api, device))
 
     async_add_entities(entities, True)
 
 
 class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
-    """Representation of a Finder Bliss Thermostat."""
+    """Representation of a Finder Bliss Thermostat.
 
+    HVAC mode mapping:
+      - HEAT = winter season (schedule or manual)
+      - COOL = summer season (schedule or manual)
+      - AUTO = resume schedule (transitions back to HEAT/COOL after refresh)
+      - OFF  = frost protection
+
+    The AUTO mode acts as a momentary trigger: selecting it sends the device
+    back to schedule mode, then the next coordinator refresh resolves it to
+    HEAT or COOL based on the active season. In Apple Home the mode briefly
+    shows "Auto" then settles to "Heat" or "Cool".
+
+    Presets select the active schedule program.
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Thermostat"
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_hvac_modes = SUPPORTED_HA_MODES
-    
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE 
-        | ClimateEntityFeature.TURN_OFF 
-        | ClimateEntityFeature.TURN_ON
-    )
-
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
     _attr_min_temp = 5.0
     _attr_max_temp = 35.0
     _attr_target_temperature_step = 0.5
 
     def __init__(self, coordinator: DataUpdateCoordinator, api: PyFinderBlissAPI, device: BlissDevice):
-        """Initialize the climate entity."""
         super().__init__(coordinator)
         self._api = api
-        
         self._device_serial = getattr(device, "serial_number", getattr(device, "name", None))
-        
         self._attr_unique_id = f"finderbliss_climate_{self._device_serial}"
+        self._command_lock = asyncio.Lock()
+
+    @property
+    def supported_features(self) -> ClimateEntityFeature:
+        features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TURN_ON
+        )
+        dev = self._find_device()
+        if dev:
+            schedules = getattr(dev, "schedules_parsed", [])
+            if any(s.get("name") for s in schedules):
+                features |= ClimateEntityFeature.PRESET_MODE
+        return features
 
     def _find_device(self) -> BlissDevice | None:
-        """Find the device in the coordinator data."""
         for d in self.coordinator.data:
             if getattr(d, "serial_number", getattr(d, "name", None)) == self._device_serial:
                 return d
         return None
 
-    # --- Properties ---
-    
-    @property
-    def name(self) -> str:
-        """Return the name of the climate device."""
+    def _get_season(self) -> str:
         dev = self._find_device()
-        base_name = getattr(dev, "name", self._device_serial)
-        return f"{base_name} Climate"
+        return getattr(dev, "season", "WINTER") if dev else "WINTER"
+
+    # --- Properties ---
 
     @property
     def current_temperature(self) -> float | None:
-        """Return the current ambient temperature."""
         dev = self._find_device()
         temp = getattr(dev, "temperature", None)
         return float(temp) if temp not in (None, "N/A") else None
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the temperature we are trying to reach (set_point)."""
-        
         dev = self._find_device()
         if dev is None:
             return None
-
-        # 1. CRITICAL: Check the HVAC mode *first*. If we are OFF, target temp must be None.
-        # This prevents the UI from trying to default to current_temperature.
         if self.hvac_mode == HVACMode.OFF:
             return None
-
-        # 2. Get the set_point value directly from the device object.
-        # Ensure we always get a string/float value.
-        set_point_raw = getattr(dev, "set_point", None) 
-            
-        # 3. Handle cases where the data might be missing or an invalid string
+        set_point_raw = getattr(dev, "set_point", None)
         if set_point_raw is None or str(set_point_raw).upper() == "N/A":
-            # If the setpoint is genuinely unavailable, return None.
             return None
-        
         try:
-            # 4. Return the value, explicitly cast to float.
             return float(set_point_raw)
         except (ValueError, TypeError):
-            # Log an error if we cannot cast the value, but return None to avoid a crash.
-            _LOGGER.error("Bliss set_point value '%s' is not a valid number.", set_point_raw)
             return None
 
     @property
     def hvac_mode(self) -> HVACMode:
-        """Return current operation mode (e.g., HEAT, AUTO, OFF)."""
         dev = self._find_device()
-        mode = getattr(dev, "mode_setting", None)
-        
-        return BLISS_TO_HA_MODE.get(str(mode).upper(), HVACMode.OFF)
+        if dev is None:
+            return HVACMode.OFF
+        mode = getattr(dev, "mode", "off")
+        if mode == "off":
+            return HVACMode.OFF
+        # Both "auto" and "manual" resolve to HEAT/COOL based on season
+        season = self._get_season()
+        return HVACMode.COOL if season == "SUMMER" else HVACMode.HEAT
 
     @property
-    def device_info(self):
-        """Return device information for device registry linking."""
+    def hvac_action(self) -> HVACAction | None:
+        dev = self._find_device()
+        if dev is None:
+            return None
+        if self.hvac_mode == HVACMode.OFF:
+            return HVACAction.OFF
+        relay_status = getattr(dev, "status", "OFF")
+        season = self._get_season()
+        if relay_status == "ON":
+            return HVACAction.COOLING if season == "SUMMER" else HVACAction.HEATING
+        return HVACAction.IDLE
+
+    @property
+    def preset_modes(self) -> list[str] | None:
+        dev = self._find_device()
+        if dev is None:
+            return None
+        schedules = getattr(dev, "schedules_parsed", [])
+        names = [s.get("name") for s in schedules if s.get("name")]
+        return names if names else None
+
+    @property
+    def preset_mode(self) -> str | None:
+        dev = self._find_device()
+        if dev is None:
+            return None
+        mode = getattr(dev, "mode", "off")
+        if mode != "auto":
+            return None
+
+        schedules = getattr(dev, "schedules_parsed", [])
+        current_auto = getattr(dev, "automatic_schedule", {})
+        if schedules and current_auto:
+            current_days = _normalize_schedule_days(current_auto.get("days", []))
+            for sched in schedules:
+                preset_days = _normalize_schedule_days(sched.get("days", []))
+                if current_days == preset_days:
+                    return sched.get("name")
+        return None
+
+    @property
+    def device_info(self) -> DeviceInfo:
         dev = self._find_device()
         serial = getattr(dev, "serial_number", self._device_serial) if dev else self._device_serial
-        return {
-            "identifiers": {(DOMAIN, serial)},
-            "name": getattr(dev, "name", self._device_serial) if dev else self._device_serial,
-            "manufacturer": "Finder",
-            "model": getattr(dev, "model", None) if dev else None,
-            "via_device": (DOMAIN, "gateway") 
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=getattr(dev, "name", self._device_serial) if dev else self._device_serial,
+            manufacturer="Finder",
+            model=getattr(dev, "model", None) if dev else None,
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return device specific attributes."""
         dev = self._find_device()
         if not dev:
             return {}
+        return {
+            "season": getattr(dev, "season", None),
+            "operating_mode": getattr(dev, "mode", None),
+        }
 
-        attrs: dict[str, Any] = {}
-        
-        attrs["raw_mode"] = getattr(dev, "mode", None)
-        attrs["raw_mode_setting"] = getattr(dev, "mode_setting", None)
-        
-        # Add the raw data attributes to the device for diagnostics/viewing
-        attrs.update(dev.raw)
-        
-        return attrs
-
-    # --- Control Methods (STABILITY FIXES APPLIED HERE) ---
+    # --- Control Methods ---
 
     async def _async_execute_api_command(self, api_coroutine, *args, **kwargs) -> None:
+        """Execute an API command and update HA state optimistically.
+
+        Serialized with a lock so concurrent commands from Apple Home
+        (e.g. HVAC mode + temperature at the same time) don't race.
+
+        The wrapper methods (set_mode, set_setpoint, etc.) update the
+        BlissDevice attributes in-place.  These are the same objects in
+        coordinator.data, so the entity properties immediately reflect
+        the new values.  We push that state to HA right away instead of
+        triggering a coordinator refresh, which would send a SyncRequest
+        over the same WebSocket and risk reading stale buffered messages.
+        The regular polling interval syncs the full state from the server.
         """
-        Executes a PyFinderBliss API command, ensuring the coordinator/connection
-        is refreshed as a first line of defense against WebSocket errors.
-        """
-        
-        # HACK/FIX: Force an initial coordinator refresh to ensure the WebSocket 
-        # is connected before attempting a control command.
-        await self.coordinator.async_request_refresh()
-        
-        try:
-            # Execute the actual API command
+        async with self._command_lock:
             await api_coroutine(*args, **kwargs)
-            
-        except RuntimeError as err:
-            # Re-raise any critical errors that aren't addressed by the refresh logic
-            if "WebSocket not connected" in str(err):
-                _LOGGER.error("Bliss API failed to connect/execute control command after refresh: %s", err)
-            raise 
-
-        # Final refresh to update HA state with the result from the thermostat
-        await self.coordinator.async_request_refresh()
-
-
-    # --- Control Methods (Using the new command executor) ---
+        self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """Set new target hvac mode."""
-        
-        bliss_mode = HA_TO_BLISS_MODE.get(hvac_mode)
-        
-        if bliss_mode is None:
-            _LOGGER.error("Unsupported HVAC mode: %s", hvac_mode)
+        """Set HVAC mode.
+
+        OFF   → frost protection
+        AUTO  → resume schedule, then resolves to HEAT/COOL on next refresh
+        HEAT  → set season to winter + manual mode
+        COOL  → set season to summer + manual mode
+        """
+        if hvac_mode == HVACMode.OFF:
+            await self._async_execute_api_command(
+                self._api.async_set_mode, self._device_serial, "OFF"
+            )
             return
 
-        try:
+        if hvac_mode == HVACMode.AUTO:
+            # Resume schedule — after refresh, hvac_mode resolves to HEAT/COOL
             await self._async_execute_api_command(
-                self._api.async_set_mode, 
-                self._device_serial, 
-                bliss_mode
+                self._api.async_set_mode, self._device_serial, "AUTO"
             )
-            
-        except Exception as err:
-            _LOGGER.error("Failed to set HVAC mode to %s for device %s: %s", 
-                          bliss_mode, self._device_serial, err)
-            # Re-raise if the error wasn't handled by the wrapper
-            raise
+            return
 
+        # HEAT or COOL → set season (if needed) + manual mode
+        # Both commands run inside one lock acquisition so no intermediate
+        # coordinator refresh can replace the device objects between them.
+        dev = self._find_device()
+        current_season = getattr(dev, "season", "WINTER") if dev else "WINTER"
+
+        async with self._command_lock:
+            if hvac_mode == HVACMode.COOL and current_season != "SUMMER":
+                await self._api.async_set_season(self._device_serial, "SUMMER")
+            elif hvac_mode == HVACMode.HEAT and current_season != "WINTER":
+                await self._api.async_set_season(self._device_serial, "WINTER")
+
+            await self._api.async_set_mode(self._device_serial, "MANUAL")
+        self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set new target temperature (set_point)."""
-
         target_temp = kwargs.get(ATTR_TEMPERATURE)
         if target_temp is None:
             return
 
-        # 1. First, ensure the device is in MANUAL/HEAT mode to accept a setpoint change
-        if self.hvac_mode != HVACMode.HEAT:
-            # NOTE: async_set_hvac_mode already uses the command executor and handles refresh
-            await self.async_set_hvac_mode(HVACMode.HEAT)
+        # Setting temperature from OFF turns the thermostat on in manual
+        if self.hvac_mode == HVACMode.OFF:
+            season = self._get_season()
+            target_hvac = HVACMode.COOL if season == "SUMMER" else HVACMode.HEAT
+            await self.async_set_hvac_mode(target_hvac)
 
-        try:
-            await self._async_execute_api_command(
-                self._api.async_set_temperature, 
-                self._device_serial, 
-                target_temp
-            )
-            
-        except Exception as err:
-            _LOGGER.error("Failed to set temperature to %s for device %s: %s", 
-                          target_temp, self._device_serial, err)
-            # Re-raise if the error wasn't handled by the wrapper
-            raise
+        await self._async_execute_api_command(
+            self._api.async_set_temperature, self._device_serial, target_temp
+        )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Apply a named schedule and switch to auto mode."""
+        await self._async_execute_api_command(
+            self._api.async_set_schedule_preset, self._device_serial, preset_mode
+        )
+        await self._async_execute_api_command(
+            self._api.async_set_mode, self._device_serial, "AUTO"
+        )

--- a/custom_components/finderblissha/config_flow.py
+++ b/custom_components/finderblissha/config_flow.py
@@ -1,5 +1,5 @@
-# finderblissha/config_flow.py
 """Config flow for Finder Bliss Home Assistant integration."""
+
 from __future__ import annotations
 
 import logging
@@ -9,16 +9,13 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-# Import the necessary constants and the API wrapper
 from .const import DOMAIN, CONF_USERNAME, CONF_PASSWORD
 from .pyfinderbliss.pyfinderbliss_wrapper import PyFinderBlissAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-# Schema for the initial user input form
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
@@ -28,71 +25,127 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, str]:
-    """Validate the user input allows us to connect.
+    """Validate the user input allows us to connect."""
+    api = PyFinderBlissAPI(data[CONF_USERNAME], data[CONF_PASSWORD])
 
-    Data contains the user input credentials.
-    Returns info dict on success, raises an exception otherwise.
-    """
-    username = data[CONF_USERNAME]
-    password = data[CONF_PASSWORD]
-
-    # Initialize the API wrapper for validation
-    api = PyFinderBlissAPI(username, password)
-    
     try:
-        # This calls the method we added earlier to pyfinderbliss_wrapper.py
         if not await api.async_validate_credentials():
-             # If validation returns False (e.g., login failed), raise invalid_auth
-             raise InvalidAuth
-    except HomeAssistantError as err:
-        # Re-raise HA errors
-        raise err
+            raise InvalidAuth
+    except HomeAssistantError:
+        raise
     except Exception as err:
-        # Catch connection errors or other unexpected API failures
-        _LOGGER.exception("Validation failed during setup: %s", err)
+        _LOGGER.exception("Validation failed: %s", err)
         raise CannotConnect from err
 
-    # If successful, return the title to be used for the config entry
-    return {"title": username}
+    return {"title": data[CONF_USERNAME]}
 
 
 class FinderBlissConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Finder Bliss."""
 
     VERSION = 1
-    # Allow only one instance of the integration
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL 
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the initial step."""
+    ) -> config_entries.ConfigFlowResult:
+        """Handle the initial setup step."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            # 1. Set unique ID to prevent duplicates
             await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
             self._abort_if_unique_id_configured()
 
-            # 2. Validate credentials
             try:
                 info = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
-            except Exception: # Catch any uncaught errors
+            except Exception:
                 _LOGGER.exception("Unexpected exception during setup.")
                 errors["base"] = "unknown"
             else:
-                # Success! Create the config entry.
                 return self.async_create_entry(title=info["title"], data=user_input)
 
-        # Show the form again if input is missing or validation failed
         return self.async_show_form(
-            step_id="user", 
-            data_schema=STEP_USER_DATA_SCHEMA, 
-            errors=errors
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle credential update from the integration page."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during reconfigure.")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={**entry.data, **user_input},
+                    title=user_input[CONF_USERNAME],
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME, default=entry.data.get(CONF_USERNAME, "")): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: dict[str, Any]
+    ) -> config_entries.ConfigFlowResult:
+        """Handle reauth when credentials expire or become invalid."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Confirm new credentials during reauth."""
+        errors: dict[str, str] = {}
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            try:
+                await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during reauth.")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={**entry.data, **user_input},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME, default=entry.data.get(CONF_USERNAME, "")): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
         )
 
 

--- a/custom_components/finderblissha/const.py
+++ b/custom_components/finderblissha/const.py
@@ -7,4 +7,4 @@ DEFAULT_SCAN_INTERVAL = 60  # seconds
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 
-PLATFORMS = ["sensor", "climate"]
+PLATFORMS = ["sensor", "climate", "select"]

--- a/custom_components/finderblissha/manifest.json
+++ b/custom_components/finderblissha/manifest.json
@@ -2,8 +2,8 @@
   "domain": "finderblissha",
   "name": "Finder Bliss Thermostats",
   "version": "0.4.6",
-  "documentation": "https://github.com/condatek/finderblissha",
-  "issue_tracker": "https://github.com/condatek/finderblissha/issues",
+  "documentation": "https://github.com/marl1w/finderblissha",
+  "issue_tracker": "https://github.com/marl1w/finderblissha/issues",
   "requirements": [],
   "codeowners": [
     "@condatek"

--- a/custom_components/finderblissha/pyfinderbliss/client.py
+++ b/custom_components/finderblissha/pyfinderbliss/client.py
@@ -1,62 +1,58 @@
-# client.py
-import aiohttp
+"""Async client for the Finder Bliss SignalR API."""
+
 import asyncio
-import json
-import uuid
 import datetime
+import json
+import logging
+import uuid
+
+import aiohttp
 
 from .const import (
     BASE_URL,
+    CLIENT_ID,
+    GRANT_TYPE,
     LOGIN_ENDPOINT,
     NEGOTIATE_URL,
-    CLIENT_ID,
-    SCOPE,
-    GRANT_TYPE,
     PING_INTERVAL,
+    SCOPE,
 )
 from .device_parser import parse_device_data
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class BlissClientAsync:
-    """
-    Asynchronous client for the Finder Bliss API with full protocol debugging.
-    """
+    """Asynchronous client for the Finder Bliss API."""
 
     def __init__(self, username: str, password: str, debug: bool = False):
         self._username = username
         self._password = password
         self._session: aiohttp.ClientSession | None = None
         self._token = None
-        self._client_id = str(uuid.uuid4()) 
+        self._client_id = str(uuid.uuid4())
         self._ws = None
         self._last_server_sync_version = 0
         self._debug = debug
 
-    def _debug_print(self, *args, **kwargs):
-        if self._debug:
-            print(*args, **kwargs)
-
     async def _ensure_session(self):
-        """Ensure aiohttp session is alive."""
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
+            self._session = aiohttp.ClientSession(
+                headers={"User-Agent": "Dalvik/2.1.0 (Linux; U; Android 7.1.1; ONEPLUS A5000 Build/NMF26X)"}
+            )
 
     async def close(self):
-        """Close WebSocket and HTTP session."""
         if self._ws and not self._ws.closed:
             await self._ws.close()
-            self._debug_print("[WS] Connection closed.")
         if self._session and not self._session.closed:
             await self._session.close()
 
     def _get_stamp(self):
-        """Generates the required ISO8601 UTC timestamp with fractional seconds."""
         return datetime.datetime.now(datetime.timezone.utc).isoformat(
             timespec="microseconds"
         ).replace('+00:00', 'Z')
 
     async def _login(self):
-        # ... (login logic remains the same)
         await self._ensure_session()
         url = f"{BASE_URL}{LOGIN_ENDPOINT}"
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -79,10 +75,9 @@ class BlissClientAsync:
             if not self._token:
                 raise Exception("Login succeeded but no access_token returned")
 
-            self._debug_print("[AUTH] Login successful, token acquired.")
+            _LOGGER.debug("Login successful, token acquired")
 
     async def _negotiate(self):
-        # ... (negotiate logic remains the same)
         if not self._token:
             await self._login()
 
@@ -94,94 +89,67 @@ class BlissClientAsync:
                 raise Exception(f"Negotiate failed ({resp.status}): {text}")
             return json.loads(text)
 
-    # --- NEW MESSAGE HANDLER FOR DEBUGGING ---
-    async def _handle_message(self, msg: aiohttp.WSMessage, ws_timeout: float | None = None):
-        """
-        Receives one message and processes all frames within it, logging them.
-        Returns a list of parsed JSON objects (frames).
-        """
+    async def _handle_message(self, msg: aiohttp.WSMessage):
         if msg.type == aiohttp.WSMsgType.TEXT:
             parsed_frames = []
             for frame in msg.data.split("\x1e"):
                 if not frame.strip():
                     continue
-                
-                self._debug_print(f"\n[SERVER RAW FRAME] >>> {frame}")
-                
+                _LOGGER.debug("Server frame: %s", frame[:200])
                 try:
                     data = json.loads(frame)
                     parsed_frames.append(data)
-                except json.JSONDecodeError as e:
-                    print(f"[SERVER ERROR] Failed to parse JSON frame: {e}")
+                except json.JSONDecodeError:
+                    _LOGGER.warning("Failed to parse JSON frame")
             return parsed_frames
-        
-        elif msg.type == aiohttp.WSMsgType.PING:
-            print("[SERVER PING] Received.")
-        elif msg.type == aiohttp.WSMsgType.PONG:
-            print("[SERVER PONG] Received.")
         elif msg.type == aiohttp.WSMsgType.CLOSE:
-            print("[SERVER CLOSE] Received close signal.")
             raise ConnectionResetError("Server closed connection.")
-        
         return []
 
     async def connect_ws(self):
-        """Establish and persist the WebSocket connection, logging handshake."""
         if not self._token:
             await self._login()
         await self._ensure_session()
-        
+
         negotiation = await self._negotiate()
         connection_id = negotiation.get("connectionId")
         ws_url = f"wss://bliss.iot.findernet.com/_sync?id={connection_id}"
         headers = {"Authorization": f"Bearer {self._token}"}
-        
-        self._debug_print(f"[WS] Connecting to: {ws_url}")
+
         self._ws = await self._session.ws_connect(
             ws_url, headers=headers, heartbeat=PING_INTERVAL
         )
-        print(f"[WS] Connection established.")
-        
-        # Handshake: '{"protocol":"json","version":1}\x1e'
+        _LOGGER.debug("WebSocket connection established")
+
         handshake_msg = json.dumps({"protocol": "json", "version": 1}) + "\x1e"
-        self._debug_print(f"[CLIENT SEND] Handshake: {handshake_msg.strip()}")
         await self._ws.send_str(handshake_msg)
-        
-        # InitRequest
+
         init_request = {
             "type": 1,
             "target": "InitRequest",
             "arguments": [
                 {
                     "clientId": self._client_id,
-                    "stamp": self._get_stamp(), 
+                    "stamp": self._get_stamp(),
                     "clientPlatform": "Android/7.1.1",
                     "clientModel": "OnePlus/ONEPLUS A5000",
                     "clientBuild": "166",
                 }
             ],
         }
-        init_req_str = json.dumps(init_request) + "\x1e"
-        self._debug_print(f"[CLIENT SEND] InitRequest: {init_req_str.strip()}")
-        await self._ws.send_str(init_req_str)
-        
-        # Wait for ack (empty object)
+        await self._ws.send_str(json.dumps(init_request) + "\x1e")
+
         while True:
             try:
                 msg = await self._ws.receive()
                 frames = await self._handle_message(msg)
-                
                 if any(f == {} for f in frames):
-                    print("[WS ACK] Initialisation acknowledged by server.")
+                    _LOGGER.debug("InitRequest acknowledged by server")
                     return
             except asyncio.TimeoutError:
                 raise Exception("Timeout waiting for InitRequest acknowledgment.")
 
     async def get_devices(self, ws_timeout: int = 15):
-        """
-        Send a Passive SyncRequest (SYNC mode) to request the full device list 
-        and update the internal server sync version.
-        """
         if not self._ws or self._ws.closed:
             await self.connect_ws()
 
@@ -193,140 +161,114 @@ class BlissClientAsync:
                     "clientId": self._client_id,
                     "clientOperationId": "00000000-0000-0000-0000-000000000000",
                     "clientSyncVersion": 0,
-                    "serverSyncVersion": 0, 
+                    "serverSyncVersion": 0,
                     "stamp": self._get_stamp(),
                     "status": "SYNC",
-                    "clientPayload": None, 
+                    "clientPayload": None,
                     "serverPayload": None,
                     "clientOperationKey": "ALL",
                     "userId": "00000000-0000-0000-0000-000000000000"
                 }
             ],
         }
-        
-        sync_req_str = json.dumps(sync_request) + "\x1e"
-        self._debug_print(f"\n[CLIENT SEND] SyncRequest (GET DEVICES): {sync_req_str.strip()}")
-        await self._ws.send_str(sync_req_str)
-        
+
+        await self._ws.send_str(json.dumps(sync_request) + "\x1e")
+
         try:
             while True:
                 msg = await asyncio.wait_for(self._ws.receive(), timeout=ws_timeout)
                 frames = await self._handle_message(msg)
-                
+
                 for data in frames:
-                    # Look for the SyncResponse from the server
-                    # WAS: if data.get("target") == "SyncResponse" and "arguments" in data:
-                    # FIX: Check for SyncRequest, as seen in the logs
-                    if data.get("target") in ("SyncRequest", "SyncResponse") and "arguments" in data: 
+                    if data.get("target") in ("SyncRequest", "SyncResponse") and "arguments" in data:
                         for arg in data["arguments"]:
                             if "serverPayload" in arg and arg["serverPayload"] is not None:
-                                
-                                # CRITICAL: Update the last received version
                                 self._last_server_sync_version = arg.get("serverSyncVersion", 0)
-                                print(f"[SYNC SUCCESS] ServerSyncVersion updated to: {self._last_server_sync_version}")
-
+                                _LOGGER.debug(
+                                    "Sync success, serverSyncVersion: %s",
+                                    self._last_server_sync_version,
+                                )
                                 payload = arg["serverPayload"]
-                                devices = parse_device_data(payload)
-                                return devices
-                                
+                                return parse_device_data(payload)
+
         except asyncio.TimeoutError:
             raise Exception(f"Timeout waiting for serverPayload after {ws_timeout} seconds.")
         except ConnectionResetError:
             raise Exception("Connection reset by server during device fetch.")
 
-
     async def send_operation(self, device_data: dict, operation_key: str = "ALL", debug_responses: int = 3):
-        """
-        Sends an ACTIVE SyncRequest (Setter mode) to change a device's state.
-        
-        Args:
-            device_data (dict): The device data containing 'handle', 'serialNumber', and 
-                                the modified 'settings' (as a Python dict) and 
-                                minimal 'measures'/'schedules' (as Python dict/list).
-        """
         if not self._ws or self._ws.closed:
-            raise RuntimeError("WebSocket not connected. Run get_devices first.")
-        
-        # 1. Prepare the payload: Ensure nested fields (settings, measures, schedules)
-        #    are converted to JSON strings before the final outer wrapper.
-        payload_to_send = dict(device_data) 
+            _LOGGER.debug("WebSocket closed before send_operation, reconnecting")
+            await self.connect_ws()
+            # Resync to get a valid _last_server_sync_version for the new session
+            await self.get_devices(ws_timeout=10)
 
-        # We must serialize nested dicts/lists into strings for the server's expected format.
+        payload_to_send = dict(device_data)
+
         for key in ["settings", "measures", "schedules"]:
             if key in payload_to_send and isinstance(payload_to_send[key], (dict, list)):
-                # Serialize the nested object into a minimal string
                 payload_to_send[key] = json.dumps(payload_to_send[key], separators=(',', ':'))
             elif key not in payload_to_send:
-                # Ensure minimal required fields are present if not provided by caller
                 payload_to_send[key] = "{}" if key in ("settings", "measures") else "[]"
-            
-        # 2. Wrap the device in the final clientPayload string
-        #    This is the outer JSON string for the 'clientPayload' field.
+
         client_payload_string = json.dumps({"devices": [payload_to_send]}, separators=(',', ':'))
 
-        # 3. Construct the main SyncRequest message
         sync_request_message = {
             "type": 1,
             "target": "SyncRequest",
             "arguments": [{
                 "clientId": self._client_id,
-                "clientOperationId": str(uuid.uuid4()), # Dynamic UUID
+                "clientOperationId": str(uuid.uuid4()),
                 "clientOperationKey": operation_key,
-                "clientSyncVersion": self._last_server_sync_version, # Critical: Use last version from SYNC
+                "clientSyncVersion": self._last_server_sync_version,
                 "serverSyncVersion": 0,
-                "clientPayload": client_payload_string, # The nested JSON string
+                "clientPayload": client_payload_string,
                 "serverPayload": None,
                 "stamp": self._get_stamp(),
-                "status": "ACTIVE", # Critical: ACTIVE mode for setters
+                "status": "ACTIVE",
             }]
         }
-        
-        sync_req_str = json.dumps(sync_request_message) + "\x1e"
-        self._debug_print(f"\n[CLIENT SEND] SyncRequest (SETTER): {sync_req_str.strip()}")
-        await self._ws.send_str(sync_req_str)
 
-        # 4. Debug: print next few server responses and look for version update
-        # ------------------- REPLACE THIS BLOCK ----------------------
+        await self._ws.send_str(json.dumps(sync_request_message) + "\x1e")
+
         new_version_received = False
         for i in range(debug_responses):
             try:
-                # Use a short timeout for waiting on command acknowledgement
-                msg = await asyncio.wait_for(self._ws.receive(), timeout=3) 
+                msg = await asyncio.wait_for(self._ws.receive(), timeout=3)
                 frames = await self._handle_message(msg)
 
                 for data in frames:
-                    # Look for the new serverSyncVersion in ANY incoming SyncRequest/SyncResponse
                     if data.get("target") in ("SyncRequest", "SyncResponse") and "arguments" in data:
                         for arg in data["arguments"]:
                             if "serverSyncVersion" in arg:
                                 self._last_server_sync_version = arg["serverSyncVersion"]
-                                print(f"[SETTER ACK] Updated serverSyncVersion: {self._last_server_sync_version}")
+                                _LOGGER.debug(
+                                    "Setter ACK, serverSyncVersion: %s",
+                                    self._last_server_sync_version,
+                                )
                                 new_version_received = True
-                                break # Found the version
+                                break
                         if new_version_received:
                             break
                 if new_version_received:
-                    break # Break out of the for i in range(debug_responses) loop
-                            
+                    break
+
             except asyncio.TimeoutError:
                 if i == 0:
-                    print("No immediate response from server after command. Continuing wait...")
+                    _LOGGER.debug("No immediate response from server after command")
                 break
             except ConnectionResetError:
                 raise Exception("Connection reset by server during command acknowledgement.")
-        # ------------------- END OF REPLACE BLOCK ----------------------
-        
-        # 5. CRITICAL STEP: Manually trigger a new SYNC request to get the device update
-        # We need the full device payload, which requires calling get_devices 
-        # using the newest self._last_server_sync_version.
-        
-        if new_version_received:
-            print("Successfully received new sync version. Attempting device refresh...")
-            # We already have a function for this, but we need to pass the version.
-            # get_devices already uses the latest version (self._last_server_sync_version)
-            try:
-                # Use a shorter timeout as the server should respond quickly
-                await self.get_devices(ws_timeout=5)
-                print("[SETTER REFRESH] Device status refreshed successfully.")
-            except Exception as e:
-                print(f"[SETTER REFRESH FAIL] Could not refresh device status: {e}")
+
+        if not new_version_received:
+            _LOGGER.warning("No ACK received from server after command")
+
+        # Drain any follow-up messages the server sends after the ACK
+        # (e.g. updated device data). If left in the buffer, the next
+        # get_devices() call would pick them up as a partial response.
+        try:
+            while True:
+                msg = await asyncio.wait_for(self._ws.receive(), timeout=1)
+                await self._handle_message(msg)
+        except asyncio.TimeoutError:
+            pass

--- a/custom_components/finderblissha/pyfinderbliss/device_parser.py
+++ b/custom_components/finderblissha/pyfinderbliss/device_parser.py
@@ -1,5 +1,11 @@
 import json
 
+MODEL_DISPLAY_NAMES = {
+    "BLISS1": "Bliss WiFi Next (1C.91)",
+    "BLISS2": "Bliss 2",
+}
+
+
 def parse_device_data(payload):
     """Parse the full serverPayload JSON into a list of device dicts."""
     try:
@@ -12,27 +18,32 @@ def parse_device_data(payload):
 
 # ----------------- MODE HANDLING -----------------
 def determine_bliss1_mode(settings: dict) -> str:
-    """Determine operating mode for BLISS1 devices."""
+    """Determine operating mode for BLISS1 devices.
+
+    BLISS1 manual mode = mode:"AUTO" + manualSchedule.isOn:true
+    (a timed override on top of the schedule).
+    mode:"OFF" = frost protection / off.
+    mode:"AUTO" + isOn:false = schedule (auto).
+    """
     is_on = settings.get("manualSchedule", {}).get("isOn", False)
     mode = settings.get("mode", "OFF").upper()
 
+    if mode == "OFF":
+        return "off"
+    if mode == "AUTO" and is_on:
+        return "manual"
     if mode == "AUTO":
         return "auto"
-    elif mode == "OFF" and is_on:
-        return "manual"
-    elif mode == "OFF" and not is_on:
-        return "off"
     return "unknown"
 
 
 def determine_bliss2_mode(measures: dict) -> str:
     """Determine operating mode for BLISS2 devices."""
     mode = measures.get("mode", 0)
-    # Aggiungo mode 2 che corrisponde a OFF/ECO/FROST
     return {
-        0: "OFF", 
-        1: "AUTO", 
-        2: "OFF",  # <-- ASSUNZIONE: Mode 2 è la modalità "SPENTO" (ECO/FROST non attivo)
+        0: "OFF",
+        1: "AUTO",
+        2: "OFF",
         3: "MANUAL"
     }.get(mode, "UNKNOWN")
 
@@ -44,17 +55,20 @@ def parse_device(device: dict) -> dict:
     Parse a single BLISS device entry into normalized dict.
     Crucially, captures raw JSON strings and all metadata needed for setter operations.
     """
-    
+
     # 1. Capture ALL MANDATORY SETTER FIELDS & RAW DATA
     handle = device.get("handle")
     tag = device.get("tag")
     name = device.get("name", "Unknown")
     serial_number = device.get("serialNumber", "Unknown")
-    model = device.get("tag", "Unknown") # Model is typically the tag
-    role = device.get("role")                          # CRITICAL for setter
-    house_handle = device.get("houseHandle")           # CRITICAL for setter
-    gateway_handle = device.get("gatewayHandle")       # CRITICAL for setter
-    is_deleted = device.get("isDeleted", False)        # CRITICAL for setter
+    model = MODEL_DISPLAY_NAMES.get(tag, tag)
+    role = device.get("role")
+    house_handle = device.get("houseHandle")
+    gateway_handle = device.get("gatewayHandle")
+    is_deleted = device.get("isDeleted", False)
+    last_update = device.get("lastUpdate")
+    timezone = device.get("tz")
+    sync_version = device.get("syncVersion", 0)
 
     # CRITICAL: Capture the raw JSON strings for resending in setter operations
     settings_raw = device.get("settings", "{}")
@@ -65,20 +79,52 @@ def parse_device(device: dict) -> dict:
     measures_parsed = safe_json_load(measures_raw)
     settings_parsed = safe_json_load(settings_raw)
 
-    # Determine mode depending on model
+    # Determine mode depending on tag
     mode = determine_bliss2_mode(measures_parsed) if tag == "BLISS2" else determine_bliss1_mode(settings_parsed)
 
     # Base attributes
     status = measures_parsed.get("status", "N/A")
     humidity = parse_value(measures_parsed.get("humidity"))
     wifi_level = measures_parsed.get("wifiLevel", "N/A")
-    battery_level = parse_value(measures_parsed.get("batteryLevel"))
+    battery_level = parse_battery_level(measures_parsed.get("batteryLevel"))
 
     # Temperature
     temperature_value = parse_temperature(measures_parsed.get("temperature"))
 
-    # Standard set point (the one thermostat is using)
-    set_point = parse_set_point(measures_parsed.get("setPoint"))
+    # Active set point
+    # In manual mode, read from settings (updated immediately after setter).
+    # In auto mode, read from measures (reported by the thermostat hardware).
+    if tag == "BLISS1":
+        if mode == "manual":
+            set_point = parse_set_point(
+                settings_parsed.get("manualSchedule", {}).get("setPoint")
+            )
+        else:
+            set_point = parse_set_point(measures_parsed.get("loggerSetPoint"))
+    else:
+        if mode == "MANUAL":
+            set_point = parse_set_point(
+                settings_parsed.get("primary", {}).get("manualSetPoint")
+            )
+        else:
+            set_point = parse_set_point(measures_parsed.get("setPoint"))
+
+    # Season (WINTER / SUMMER)
+    season = settings_parsed.get("season")
+
+    # Thermal differential (hysteresis) — stored in tenths of °C
+    thermal_differential_raw = settings_parsed.get("thermalDifferential")
+    thermal_differential = thermal_differential_raw / 10 if isinstance(thermal_differential_raw, (int, float)) else None
+
+    # Update interval (sync frequency in minutes)
+    update_step_raw = settings_parsed.get("updateStep")
+    update_step = int(update_step_raw) if update_step_raw is not None else None
+
+    # Automatic schedule (the currently active schedule program)
+    automatic_schedule = settings_parsed.get("automaticSchedule", {})
+
+    # Named schedule presets (parsed from the schedules JSON array)
+    schedules_parsed = safe_json_load_list(schedules_raw)
 
     # Manual set point (user override value)
     if tag == "BLISS2":
@@ -104,19 +150,27 @@ def parse_device(device: dict) -> dict:
         "mode_setting": mode_setting,
         "wifi_level": wifi_level,
         "battery_level": battery_level,
-        
+        "season": season,
+        "thermal_differential": thermal_differential,
+        "update_step": update_step,
+        "automatic_schedule": automatic_schedule,
+        "schedules_parsed": schedules_parsed,
+        "last_update": last_update,
+        "timezone": timezone,
+
         # CRITICAL SETTER METADATA (snake_case keys)
         "role": device.get("role"),
         "house_handle": device.get("houseHandle"),
         "gateway_handle": device.get("gatewayHandle"),
         "is_deleted": device.get("isDeleted", False),
-        "tag": device.get("tag"),                         # Ensure 'tag' is returned
-        "channel": device.get("channel"),                 # Ensure 'channel' is returned if present
-        
+        "tag": device.get("tag"),
+        "channel": device.get("channel"),
+        "sync_version": sync_version,
+
         # CRITICAL RAW JSON STRINGS (for setter payload)
-        "settings": settings_raw,   # Full raw JSON string
-        "measures": measures_raw,   # Full raw JSON string
-        "schedules": schedules_raw, # Full raw JSON string
+        "settings": settings_raw,
+        "measures": measures_raw,
+        "schedules": schedules_raw,
     }
 
 
@@ -133,8 +187,21 @@ def safe_json_load(data):
     return {}
 
 
+def safe_json_load_list(data):
+    """Safely loads JSON strings into list, returns [] on failure."""
+    if isinstance(data, str):
+        try:
+            result = json.loads(data)
+            return result if isinstance(result, list) else []
+        except json.JSONDecodeError:
+            return []
+    elif isinstance(data, list):
+        return data
+    return []
+
+
 def parse_temperature(temp_data):
-    """Parse and normalize temperature (tenths of °C → °C)."""
+    """Parse and normalize temperature (tenths of C to C)."""
     if isinstance(temp_data, dict):
         value = temp_data.get("value")
     else:
@@ -146,7 +213,7 @@ def parse_temperature(temp_data):
 
 
 def parse_set_point(set_point_data):
-    """Parse and normalize set point values (tenths of °C → °C)."""
+    """Parse and normalize set point values (tenths of C to C)."""
     if isinstance(set_point_data, dict):
         value = set_point_data.get("value")
     else:
@@ -155,6 +222,25 @@ def parse_set_point(set_point_data):
     if isinstance(value, (int, float)):
         return value / 10
     return "N/A"
+
+
+def parse_battery_level(raw):
+    """Convert raw battery voltage (tenths of volts) to percentage.
+
+    4xAA (2S2P): ~3.0V fresh, ~2.1V cutoff.
+    Calibrated against the Finder Bliss iOS app's 3-dot display:
+      1 dot  = below ~2.55V
+      2 dots = ~2.55V to ~2.85V
+      3 dots = above ~2.85V
+    """
+    if isinstance(raw, dict):
+        raw = raw.get("value")
+    if not isinstance(raw, (int, float)):
+        return "N/A"
+    VOLTAGE_MAX = 30  # 3.0V (fresh 2S2P alkaline)
+    VOLTAGE_MIN = 21  # 2.1V (cutoff)
+    pct = (raw - VOLTAGE_MIN) / (VOLTAGE_MAX - VOLTAGE_MIN) * 100
+    return max(0, min(100, round(pct)))
 
 
 def parse_value(value):

--- a/custom_components/finderblissha/pyfinderbliss/pyfinderbliss_wrapper.py
+++ b/custom_components/finderblissha/pyfinderbliss/pyfinderbliss_wrapper.py
@@ -9,174 +9,211 @@ class BlissDevice:
         self.name = device_data.get("name")
         self.temperature = device_data.get("temperature")
         self.humidity = device_data.get("humidity")
-        self.set_point = device_data.get("set_point")  # match parser key
-        self.manual_set_point = device_data.get("manual_set_point")  # match parser key
+        self.set_point = device_data.get("set_point")
+        self.manual_set_point = device_data.get("manual_set_point")
         self.mode = device_data.get("mode")
-        self.mode_setting = device_data.get("mode_setting")  # add this too
-        self.wifi_level = device_data.get("wifi_level")      # add this too
+        self.mode_setting = device_data.get("mode_setting")
+        self.wifi_level = device_data.get("wifi_level")
         self.battery_level = device_data.get("battery_level")
         self.status = device_data.get("status")
         self.serial_number = device_data.get("serial_number")
         self.model = device_data.get("model")
         self.raw = device_data
-        
-        # Add the CRITICAL SETTER METADATA fields (must match parser keys: snake_case)
+
         self.role = device_data.get("role")
-        self.house_handle = device_data.get("house_handle")       
+        self.house_handle = device_data.get("house_handle")
         self.gateway_handle = device_data.get("gateway_handle")
         self.is_deleted = device_data.get("is_deleted")
-        self.tag = device_data.get("tag")              # FIX: Add tag (used for model/mode logic)
-        self.channel = device_data.get("channel")      # Add channel if it's in your parser output
+        self.tag = device_data.get("tag")
+        self.channel = device_data.get("channel")
 
-        # Add these lines:
         self.settings = device_data.get("settings", {})
         self.measures = device_data.get("measures", {})
         self.schedules = device_data.get("schedules", [])
 
-    async def set_mode(self, mode: str):
-        """
-        Change device mode using the full protocol SyncRequest setter.
-        Requires sending the entire device object with the desired setting changed.
-        mode: 'OFF', 'AUTO', 'MANUAL', 'FROST', 'ECO' (must be uppercase)
-        """
-        mode = mode.upper()
-        
-        # Ensure the client is available
+        self.season = device_data.get("season")
+        self.thermal_differential = device_data.get("thermal_differential")
+        self.update_step = device_data.get("update_step")
+        self.schedules_parsed = device_data.get("schedules_parsed", [])
+        self.automatic_schedule = device_data.get("automatic_schedule", {})
+        self.last_update = device_data.get("last_update")
+        self.timezone = device_data.get("timezone")
+        self.sync_version = device_data.get("sync_version", 0)
+
+    def _build_send_payload(self, modified_settings_string: str) -> dict:
+        return {
+            "handle": self.handle,
+            "serialNumber": self.serial_number,
+            "name": self.name,
+            "settings": modified_settings_string,
+            "measures": self.measures,
+            "schedules": self.schedules,
+            "houseHandle": self.house_handle,
+            "tag": self.tag,
+            "channel": self.channel,
+            "status": "PENDING",
+            "syncVersion": self.sync_version,
+            "isDeleted": self.is_deleted,
+            "role": self.role,
+            "gatewayHandle": self.gateway_handle,
+        }
+
+    def _ensure_client(self):
         if not hasattr(self, "_client") or self._client is None:
             raise Exception("Device client not initialized")
 
-        # 1. Start with the CURRENT state and modify ONLY the necessary part
-        # self.settings is a JSON string, so we must load it to modify it.
-        settings_dict = json.loads(self.settings)
-        
-        # 2. Update the 'primary' object in settings
-        if self.model in ["BLISS2", "BLISS-HA"]:
-            # --- Your mode change logic is integrated here ---
+    def _load_settings(self) -> dict:
+        try:
+            return json.loads(self.settings) if isinstance(self.settings, str) else dict(self.settings)
+        except (TypeError, json.JSONDecodeError):
+            return {}
+
+    def _serialize_settings(self, settings_dict: dict) -> str:
+        return json.dumps(settings_dict, separators=(',', ':'))
+
+    async def set_mode(self, mode: str):
+        """Change device mode. mode: 'OFF', 'AUTO', 'MANUAL', 'FROST', 'ECO' (uppercase)."""
+        mode = mode.upper()
+        self._ensure_client()
+
+        settings_dict = self._load_settings()
+
+        if self.tag == "BLISS1":
+            if mode == "AUTO":
+                settings_dict["mode"] = "AUTO"
+                settings_dict.setdefault("manualSchedule", {})["isOn"] = False
+            elif mode == "MANUAL":
+                # BLISS1 manual = mode stays "AUTO", manualSchedule acts as
+                # a timed override (matching the iOS Finder Bliss app behavior).
+                settings_dict["mode"] = "AUTO"
+                ms = settings_dict.setdefault("manualSchedule", {})
+                ms["isOn"] = True
+                if ms.get("setPoint") is None:
+                    current_sp = self.set_point if isinstance(self.set_point, (int, float)) else 18.0
+                    ms["setPoint"] = int(current_sp * 10)
+                self._set_manual_timer(ms)
+            elif mode in ("OFF", "FROST"):
+                settings_dict["mode"] = "OFF"
+                settings_dict.setdefault("manualSchedule", {})["isOn"] = False
+            else:
+                raise ValueError(f"Unsupported BLISS1 mode: {mode}")
+
+        elif self.tag in ("BLISS2", "BLISS-HA"):
             if mode in ["AUTO", "OFF", "FROST", "ECO"]:
                 settings_dict["primary"] = {
                     "mode": mode,
                     "manualSetPoint": None
                 }
             elif mode == "MANUAL":
-                # Ensure a manualSetPoint is present for MANUAL mode
-                if settings_dict["primary"].get("manualSetPoint") is None:
-                    # Use current set_point as a fallback, default to 18.0C (180) if not available
-                    current_sp_value = int((self.set_point or 18.0) * 10)
-                    settings_dict["primary"]["manualSetPoint"] = {"unit": "C", "value": current_sp_value, "preset": 0} 
-                    
-                settings_dict["primary"]["mode"] = mode
+                if settings_dict.get("primary", {}).get("manualSetPoint") is None:
+                    current_sp = self.set_point if isinstance(self.set_point, (int, float)) else 18.0
+                    current_sp_value = int(current_sp * 10)
+                    settings_dict.setdefault("primary", {})["manualSetPoint"] = {"unit": "C", "value": current_sp_value, "preset": 0}
+                settings_dict.setdefault("primary", {})["mode"] = mode
             else:
                 raise ValueError(f"Unsupported mode: {mode}")
-            
-        # CRITICAL FIX: The presence of manualTimer overrides primary.mode.
-        # We must delete it to ensure the mode change (or new manual setpoint) is honored.
-        if "manualTimer" in settings_dict:
-            del settings_dict["manualTimer"]
 
-        # 3. Serialize the full settings dict back into a tight JSON string
-        # This is the string that will be sent inside the outer clientPayload string.
-        modified_settings_string = json.dumps(settings_dict, separators=(',', ':'))
-        
-        # 4. Construct the FULL device object required for clientPayload
-        device_data_to_send = {
-            # Core identification fields (from parser)
-            "handle": self.handle,
-            "serialNumber": self.serial_number,
-            "name": self.name,
-            
-            # Full Settings (as a string) - This is the ONLY field that changes
-            "settings": modified_settings_string, 
-            
-            # CRITICAL: Send the FULL current state of these fields (already strings from parsing)
-            "measures": self.measures, 
-            "schedules": self.schedules,
-            
-            # CRITICAL: Include all other required top-level fields (from parser)
-            "houseHandle": self.house_handle,     # Assuming you store this from parse_device
-            "tag": self.tag,                     # Assuming you store this
-            "channel": self.channel,               # Assuming you store this
-            
-            # CRITICAL: Setter-specific fields from captured traffic
-            "status": "PENDING",                   # Required status for setter
-            "syncVersion": 0,                      # Required value for setter
-            "isDeleted": self.is_deleted,          # Assuming you store this
-            "role": self.role,                     # Assuming you store this
-            "gatewayHandle": self.gateway_handle,  # Assuming you store this
-        }
-        
-        # 5. Call the client's command method to send the active SyncRequest
-        # NOTE: The client.py function will now handle the final outer JSON serialization
-        await self._client.send_operation(device_data=device_data_to_send)
-        
-        # 6. Update local state
-        # IMPORTANT: We store the string representation for future use
-        self.settings = modified_settings_string
-        self.mode = mode
+            # BLISS2: manualTimer overrides primary.mode, remove it
+            if "manualTimer" in settings_dict:
+                del settings_dict["manualTimer"]
 
+        modified = self._serialize_settings(settings_dict)
+        await self._client.send_operation(device_data=self._build_send_payload(modified))
+        self.settings = modified
+        self.mode = mode.lower() if mode in ("AUTO", "MANUAL") else "off"
+
+    def _set_manual_timer(self, ms: dict, duration_hours: int = 1) -> None:
+        """Set manualSchedule start/stop timestamps in the device's local timezone.
+
+        The thermostat interprets these as local time (no TZ suffix),
+        so we must use the device's timezone, not UTC.
+        """
+        import datetime
+        import zoneinfo
+        tz = zoneinfo.ZoneInfo(self.timezone) if self.timezone else None
+        now = datetime.datetime.now(tz) if tz else datetime.datetime.now()
+        ms["start"] = now.strftime("%Y-%m-%dT%H:%M:%S")
+        ms["stop"] = (now + datetime.timedelta(hours=duration_hours)).strftime("%Y-%m-%dT%H:%M:%S")
 
     async def set_setpoint(self, value: float):
-        """
-        Changes the setpoint temperature by forcing the device into MANUAL mode
-        and setting the primary manual setpoint.
-        """
-        if not hasattr(self, "_client") or self._client is None:
-            raise Exception("Device client not initialized")
+        """Set the target temperature, forcing MANUAL mode."""
+        self._ensure_client()
 
-        # 1. Load current settings (string → dict)
-        try:
-            settings_dict = json.loads(self.settings)
-        except (TypeError, json.JSONDecodeError):
-            settings_dict = {}
-        
-        # Calculate target value (Value * 10)
+        settings_dict = self._load_settings()
         target_value_int = int(value * 10)
 
-        # 2. Set the device to MANUAL mode and set the value
-        if "primary" not in settings_dict:
-            settings_dict["primary"] = {}
-            
-        settings_dict["primary"]["mode"] = "MANUAL"
-        settings_dict["primary"]["manualSetPoint"] = {
-            "unit": "C",
-            "value": target_value_int,
-            "preset": 0
-        }
-        
-        # 3. CRUCIAL FIX: Remove the manualTimer to switch to permanent manual mode
-        # If the manualTimer field exists, it overrides primary.mode
-        if "manualTimer" in settings_dict:
-            # We must delete the key entirely to confirm the mode change
-            del settings_dict["manualTimer"] 
-            
-        # 4. Serialize back the modified settings string
-        # Use separators=(',', ':') to match the compacted app payload format
-        modified_settings_string = json.dumps(settings_dict, separators=(',', ':'))
+        if self.tag == "BLISS1":
+            # BLISS1: mode stays "AUTO", manualSchedule is a timed override
+            settings_dict["mode"] = "AUTO"
+            ms = settings_dict.setdefault("manualSchedule", {})
+            ms["isOn"] = True
+            ms["setPoint"] = target_value_int
+            self._set_manual_timer(ms)
+        else:
+            # BLISS2 / BLISS-HA
+            settings_dict.setdefault("primary", {})["mode"] = "MANUAL"
+            settings_dict["primary"]["manualSetPoint"] = {
+                "unit": "C",
+                "value": target_value_int,
+                "preset": 0
+            }
+            if "manualTimer" in settings_dict:
+                del settings_dict["manualTimer"]
 
-        # 5. Build the complete device object for clientPayload (Use device's own properties)
-        device_data_to_send = {
-            "handle": self.handle,
-            "serialNumber": self.serial_number,
-            "name": self.name,
-            "settings": modified_settings_string,
-            # Pass through existing values for other key fields
-            "measures": self.measures, 
-            "schedules": self.schedules,
-            "houseHandle": self.house_handle,
-            "tag": self.tag,
-            "channel": self.channel,
-            "status": "PENDING",
-            "syncVersion": 0, # syncVersion MUST be 0 for a SETTER request
-            "isDeleted": self.is_deleted,
-            "role": self.role,
-            "gatewayHandle": self.gateway_handle,
-        }
-
-        # 6. Send full SyncRequest
-        await self._client.send_operation(device_data=device_data_to_send)
-
-        # 7. Update local state
-        self.settings = modified_settings_string
+        modified = self._serialize_settings(settings_dict)
+        await self._client.send_operation(device_data=self._build_send_payload(modified))
+        self.settings = modified
         self.set_point = value
+        self.mode = "manual"
+
+    async def set_season(self, season: str):
+        """Change the season (WINTER/SUMMER) for heating/cooling."""
+        season = season.upper()
+        if season not in ("WINTER", "SUMMER"):
+            raise ValueError(f"Invalid season: {season}")
+
+        self._ensure_client()
+
+        settings_dict = self._load_settings()
+        settings_dict["season"] = season
+
+        modified = self._serialize_settings(settings_dict)
+        await self._client.send_operation(device_data=self._build_send_payload(modified))
+        self.settings = modified
+        self.season = season
+
+    async def set_update_step(self, minutes: int):
+        """Change the sync/update interval in minutes."""
+        self._ensure_client()
+
+        settings_dict = self._load_settings()
+        settings_dict["updateStep"] = str(minutes)
+
+        modified = self._serialize_settings(settings_dict)
+        await self._client.send_operation(device_data=self._build_send_payload(modified))
+        self.settings = modified
+        self.update_step = minutes
+
+    async def set_schedule_preset(self, preset_name: str):
+        """Apply a named schedule preset to the automaticSchedule."""
+        self._ensure_client()
+
+        target_preset = None
+        for sched in self.schedules_parsed:
+            if sched.get("name") == preset_name:
+                target_preset = sched
+                break
+        if target_preset is None:
+            raise ValueError(f"Schedule preset '{preset_name}' not found")
+
+        settings_dict = self._load_settings()
+        settings_dict["automaticSchedule"] = {"days": target_preset["days"]}
+
+        modified = self._serialize_settings(settings_dict)
+        await self._client.send_operation(device_data=self._build_send_payload(modified))
+        self.settings = modified
+        self.automatic_schedule = {"days": target_preset["days"]}
+
 
 class PyFinderBlissAPI:
     def __init__(self, username: str, password: str, max_retries=3, retry_delay=5):
@@ -188,46 +225,32 @@ class PyFinderBlissAPI:
         self._retry_delay = retry_delay
 
     async def _async_ensure_authenticated(self):
-        """
-        Internal helper to ensure the client is logged in and the WebSocket is active.
-        Re-creates the client and logs in if the existing one is not active.
-        NOTE: Assumes BlissClientAsync has a property like `is_logged_in` or `websocket_is_connected`.
-        """
-        # Assume _client.is_logged_in checks both token and websocket status.
         if hasattr(self._client, "is_logged_in") and self._client.is_logged_in:
             return
 
-        # 1. Try to use the existing client to login/reconnect
         try:
-            # We use the private _login assuming it handles initial setup/reconnect
             await self._client._login()
             return
         except Exception:
-            # 2. If re-login fails, close and re-create a fresh client instance
             try:
                 await self._client.close()
             except Exception:
                 pass
-            
+
             self._client = BlissClientAsync(self._username, self._password)
             await self._client._login()
 
     async def async_setup(self):
-        # Use the new robust setup method
         await self._async_ensure_authenticated()
 
-    # --- NEW: Credential Validation (For config_flow.py) ---
     async def async_validate_credentials(self) -> bool:
         """Test the connection and credentials by attempting a login."""
-        # Use a fresh client to avoid interference with the main client's state
         temp_client = BlissClientAsync(self._username, self._password)
         try:
-            # Attempt the private login method (since that's what async_setup uses)
             await temp_client._login()
             await temp_client.close()
             return True
         except Exception:
-            # Catch login failure, connection errors, etc.
             try:
                 await temp_client.close()
             except Exception:
@@ -235,7 +258,6 @@ class PyFinderBlissAPI:
             return False
 
     async def async_get_devices(self):
-        # Ensure connection before starting the fetch loop
         await self._async_ensure_authenticated()
 
         for attempt in range(self._max_retries):
@@ -243,71 +265,76 @@ class PyFinderBlissAPI:
                 devices_data = await self._client.get_devices()
                 self._devices = [BlissDevice(d) for d in devices_data]
 
-                # Attach client reference so setters work
                 for dev in self._devices:
                     dev._client = self._client
-                    
+
                 return self._devices
 
             except Exception as e:
                 print(f"[FinderBliss] Device fetch failed (attempt {attempt+1}): {e}")
-                
-                # After a network failure, try to re-authenticate and retry
+
                 if attempt < self._max_retries - 1:
                     await self._async_ensure_authenticated()
                     await asyncio.sleep(self._retry_delay)
                     continue
 
-                # If this was the last attempt, break
                 break
 
         raise Exception("Failed to fetch devices after retries")
-    
-    # --- Utility Method (NEW) ---
+
     def _find_device_by_serial(self, serial: str) -> Union['BlissDevice', None]:
-        """Internal helper to find a device object by its serial number or name."""
-        # Check against serial_number first, fall back to name if serial_number is missing/None
         return next(
-            (d for d in self._devices 
-             if getattr(d, 'serial_number', getattr(d, 'name')) == serial), 
+            (d for d in self._devices
+             if getattr(d, 'serial_number', getattr(d, 'name')) == serial),
             None
         )
 
-    # --- NEW: Control Method for Home Assistant Climate Platform ---
     async def async_set_temperature(self, device_serial: str, temperature: float):
-        """Set the target setpoint for the device, delegated to the BlissDevice object."""
-        # Ensure connection is active before sending the setter command
         await self._async_ensure_authenticated()
-
         device = self._find_device_by_serial(device_serial)
         if not device:
             raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
-        
         await device.set_setpoint(value=temperature)
 
-
     async def async_set_mode(self, device_serial: str, mode: str):
-        """Set the operating mode for the device, delegated to the BlissDevice object."""
-        # Ensure connection is active before sending the setter command
         await self._async_ensure_authenticated()
-
         device = self._find_device_by_serial(device_serial)
         if not device:
             raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
-            
         await device.set_mode(mode=mode)
+
+    async def async_set_season(self, device_serial: str, season: str):
+        await self._async_ensure_authenticated()
+        device = self._find_device_by_serial(device_serial)
+        if not device:
+            raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
+        await device.set_season(season=season)
+
+    async def async_set_update_step(self, device_serial: str, minutes: int):
+        await self._async_ensure_authenticated()
+        device = self._find_device_by_serial(device_serial)
+        if not device:
+            raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
+        await device.set_update_step(minutes=minutes)
+
+    async def async_set_schedule_preset(self, device_serial: str, preset_name: str):
+        await self._async_ensure_authenticated()
+        device = self._find_device_by_serial(device_serial)
+        if not device:
+            raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
+        await device.set_schedule_preset(preset_name=preset_name)
 
     async def async_close(self):
         await self._client.close()
 
-# Example usage for Home Assistant integration
+
 async def async_main():
     api = PyFinderBlissAPI("123", "123")
     try:
         await api.async_setup()
         devices = await api.async_get_devices()
         for dev in devices:
-            print(f"{dev.name}: temp={dev.temperature}, hum={dev.humidity}, setpoint={dev.set_point}, mode={dev.mode}")
+            print(f"{dev.name}: temp={dev.temperature}, hum={dev.humidity}, setpoint={dev.set_point}, mode={dev.mode}, season={dev.season}")
     finally:
         await api.async_close()
 

--- a/custom_components/finderblissha/select.py
+++ b/custom_components/finderblissha/select.py
@@ -1,0 +1,103 @@
+"""Select platform for Finder Bliss — sync interval profile."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
+from .pyfinderbliss.pyfinderbliss_wrapper import BlissDevice, PyFinderBlissAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_PROFILES: dict[str, int] = {
+    "Energy saving": 1,
+    "Normal": 2,
+    "Fast": 3,
+    "Super fast": 4,
+}
+
+LEVEL_TO_PROFILE: dict[int, str] = {v: k for k, v in UPDATE_PROFILES.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinator: DataUpdateCoordinator = entry_data["coordinator"]
+    api: PyFinderBlissAPI = entry_data["api"]
+
+    entities = []
+    for device in coordinator.data:
+        if not isinstance(device, BlissDevice):
+            continue
+        if getattr(device, "update_step", None) is not None:
+            entities.append(FinderBlissUpdateProfileSelect(coordinator, api, device))
+
+    async_add_entities(entities, True)
+
+
+class FinderBlissUpdateProfileSelect(CoordinatorEntity, SelectEntity):
+    """Sync interval profile for a Finder Bliss thermostat."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Sync profile"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = list(UPDATE_PROFILES.keys())
+
+    def __init__(self, coordinator: DataUpdateCoordinator, api: PyFinderBlissAPI, device: BlissDevice):
+        super().__init__(coordinator)
+        self._api = api
+        self._device_serial = getattr(device, "serial_number", getattr(device, "name", None))
+        self._attr_unique_id = f"finderbliss_{self._device_serial}_update_profile"
+
+    def _find_device(self) -> BlissDevice | None:
+        for d in self.coordinator.data:
+            if getattr(d, "serial_number", getattr(d, "name", None)) == self._device_serial:
+                return d
+        return None
+
+    @property
+    def current_option(self) -> str | None:
+        dev = self._find_device()
+        if not dev:
+            return None
+        level = getattr(dev, "update_step", None)
+        if level is None:
+            return None
+        return LEVEL_TO_PROFILE.get(level, "Normal")
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        dev = self._find_device()
+        level = getattr(dev, "update_step", None) if dev else None
+        return {"sync_level": level}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        dev = self._find_device()
+        serial = getattr(dev, "serial_number", self._device_serial) if dev else self._device_serial
+        return DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=getattr(dev, "name", self._device_serial) if dev else self._device_serial,
+            manufacturer="Finder",
+            model=getattr(dev, "model", None) if dev else None,
+        )
+
+    async def async_select_option(self, option: str) -> None:
+        level = UPDATE_PROFILES.get(option)
+        if level is None:
+            _LOGGER.error("Unknown sync profile: %s", option)
+            return
+        await self._api.async_set_update_step(self._device_serial, level)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/finderblissha/sensor.py
+++ b/custom_components/finderblissha/sensor.py
@@ -1,15 +1,27 @@
 """Sensor platform for Finder Bliss (BLISS1 / BLISS2)."""
 
 from __future__ import annotations
+
 import logging
 
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
-    DataUpdateCoordinator,
     CoordinatorEntity,
+    DataUpdateCoordinator,
 )
 
 from .const import DOMAIN
@@ -17,39 +29,32 @@ from .pyfinderbliss.pyfinderbliss_wrapper import BlissDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up the sensor platform from a config entry."""
-    
-    # FIX: Recupera i dati utilizzando la struttura per entry.entry_id
     try:
         entry_data = hass.data[DOMAIN][entry.entry_id]
     except KeyError:
-        _LOGGER.error("Configuration entry data not found for sensor platform. Check __init__.py storage.")
+        _LOGGER.error("Configuration entry data not found for sensor platform")
         return
 
     coordinator: DataUpdateCoordinator = entry_data.get("coordinator")
-    
     if not coordinator:
-        # Questa riga non dovrebbe più essere raggiunta se l'accesso a entry_data va a buon fine,
-        # ma la manteniamo per sicurezza.
         _LOGGER.error("Coordinator not found for sensor platform")
         return
 
-    # coordinator already refreshed in __init__.py
-    
     entities = build_entities_from_devices(coordinator)
     async_add_entities(entities, True)
 
 
-# -------------------------
-# Entity builder
-# -------------------------
 def build_entities_from_devices(coordinator: DataUpdateCoordinator):
     entities = []
     for device in coordinator.data:
         if not isinstance(device, BlissDevice):
             continue
-        _LOGGER.debug(f"Processing device: {device.name}")
+        _LOGGER.debug("Processing device: %s", device.name)
 
         if device.temperature not in (None, "N/A"):
             entities.append(FinderBlissTemperatureSensor(coordinator, device))
@@ -65,37 +70,39 @@ def build_entities_from_devices(coordinator: DataUpdateCoordinator):
             entities.append(FinderBlissManualSetPointSensor(coordinator, device))
         if getattr(device, "set_point", None) not in (None, "N/A"):
             entities.append(FinderBlissSetPointSensor(coordinator, device))
+        if getattr(device, "season", None) is not None:
+            entities.append(FinderBlissSeasonSensor(coordinator, device))
+        if getattr(device, "thermal_differential", None) is not None:
+            entities.append(FinderBlissThermalDifferentialSensor(coordinator, device))
+        if getattr(device, "automatic_schedule", None):
+            entities.append(FinderBlissScheduleSensor(coordinator, device))
+        if getattr(device, "last_update", None) is not None:
+            entities.append(FinderBlissLastUpdateSensor(coordinator, device))
     return entities
 
 
-# -------------------------
-# Base sensor
-# -------------------------
 class FinderBlissBaseSensor(CoordinatorEntity, SensorEntity):
-    def __init__(self, coordinator: DataUpdateCoordinator, device: BlissDevice, key: str, friendly: str, unit: str | None, attr: str):
+    """Base sensor for Finder Bliss entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        device: BlissDevice,
+        key: str,
+        attr: str,
+    ):
         super().__init__(coordinator)
         self._device_serial = getattr(device, "serial_number", getattr(device, "name", None))
-        self._key = key
-        self._friendly = friendly
-        self._unit = unit
         self._attr = attr
-        self._unique_id = f"finderbliss_{self._device_serial}_{key}"
+        self._attr_unique_id = f"finderbliss_{self._device_serial}_{key}"
 
-    def _find_device(self):
+    def _find_device(self) -> BlissDevice | None:
         for d in self.coordinator.data:
             if getattr(d, "serial_number", getattr(d, "name", None)) == self._device_serial:
                 return d
         return None
-
-    @property
-    def name(self) -> str:
-        dev = self._find_device()
-        base_name = getattr(dev, "name", self._device_serial)
-        return f"{base_name} {self._friendly}"
-
-    @property
-    def unique_id(self) -> str:
-        return self._unique_id
 
     @property
     def native_value(self):
@@ -106,64 +113,225 @@ class FinderBlissBaseSensor(CoordinatorEntity, SensorEntity):
         return None if val == "N/A" else val
 
     @property
-    def native_unit_of_measurement(self):
-        return self._unit
-
-    @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         dev = self._find_device()
         serial = getattr(dev, "serial_number", self._device_serial) if dev else self._device_serial
-        return {
-            "identifiers": {(DOMAIN, serial)},
-            "name": getattr(dev, "name", self._device_serial) if dev else self._device_serial,
-            "manufacturer": "Finder",
-            "model": getattr(dev, "model", None) if dev else None,
-        }
-
-    @property
-    def extra_state_attributes(self):
-        dev = self._find_device()
-        attrs = {"status": getattr(dev, "status", None)}
-        raw = getattr(dev, "raw", None)
-        if raw:
-            attrs["raw"] = raw
-        return attrs
+        return DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=getattr(dev, "name", self._device_serial) if dev else self._device_serial,
+            manufacturer="Finder",
+            model=getattr(dev, "model", None) if dev else None,
+        )
 
 
-# -------------------------
-# Specific sensors
-# -------------------------
 class FinderBlissTemperatureSensor(FinderBlissBaseSensor):
+    _attr_name = "Temperature"
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
     def __init__(self, coordinator, device):
-        super().__init__(coordinator, device, "temperature", "Temperature", UnitOfTemperature.CELSIUS, "temperature")
+        super().__init__(coordinator, device, "temperature", "temperature")
 
 
 class FinderBlissHumiditySensor(FinderBlissBaseSensor):
+    _attr_name = "Humidity"
+    _attr_device_class = SensorDeviceClass.HUMIDITY
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
     def __init__(self, coordinator, device):
-        super().__init__(coordinator, device, "humidity", "Humidity", PERCENTAGE, "humidity")
+        super().__init__(coordinator, device, "humidity", "humidity")
 
 
 class FinderBlissBatterySensor(FinderBlissBaseSensor):
+    _attr_name = "Battery"
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(self, coordinator, device):
-        super().__init__(coordinator, device, "battery", "Battery", PERCENTAGE, "battery_level")
+        super().__init__(coordinator, device, "battery", "battery_level")
 
 
 class FinderBlissWifiSensor(FinderBlissBaseSensor):
+    _attr_name = "WiFi level"
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(self, coordinator, device):
-        super().__init__(coordinator, device, "wifi", "WiFi Level", "dBm", "wifi_level")
+        super().__init__(coordinator, device, "wifi", "wifi_level")
 
 
 class FinderBlissModeSensor(FinderBlissBaseSensor):
+    _attr_name = "Mode"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(self, coordinator, device):
-        super().__init__(coordinator, device, "mode", "Mode", None, "mode")
+        super().__init__(coordinator, device, "mode", "mode")
 
 
 class FinderBlissManualSetPointSensor(FinderBlissBaseSensor):
+    _attr_name = "Manual set point"
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
     def __init__(self, coordinator, device):
-        super().__init__(coordinator, device, "manual_set_point", "Manual Set Point", UnitOfTemperature.CELSIUS, "manual_set_point")
+        super().__init__(coordinator, device, "manual_set_point", "manual_set_point")
 
 
 class FinderBlissSetPointSensor(FinderBlissBaseSensor):
-    def __init__(self, coordinator, device):
-        super().__init__(coordinator, device, "set_point", "Set Point", UnitOfTemperature.CELSIUS, "set_point")
+    _attr_name = "Set point"
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
+    def __init__(self, coordinator, device):
+        super().__init__(coordinator, device, "set_point", "set_point")
+
+
+class FinderBlissSeasonSensor(FinderBlissBaseSensor):
+    _attr_name = "Season"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, device):
+        super().__init__(coordinator, device, "season", "season")
+
+
+class FinderBlissThermalDifferentialSensor(FinderBlissBaseSensor):
+    _attr_name = "Thermal differential"
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, device):
+        super().__init__(coordinator, device, "thermal_differential", "thermal_differential")
+
+
+class FinderBlissLastUpdateSensor(FinderBlissBaseSensor):
+    _attr_name = "Last sync"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, device):
+        super().__init__(coordinator, device, "last_update", "last_update")
+
+    @property
+    def native_value(self):
+        dev = self._find_device()
+        if not dev:
+            return None
+        raw = getattr(dev, "last_update", None)
+        if not raw:
+            return None
+        from datetime import datetime
+        try:
+            tz_name = getattr(dev, "timezone", None)
+            import zoneinfo
+            tz = zoneinfo.ZoneInfo(tz_name) if tz_name else None
+            dt = datetime.fromisoformat(raw)
+            if dt.tzinfo is None and tz:
+                dt = dt.replace(tzinfo=tz)
+            return dt
+        except (ValueError, KeyError):
+            return None
+
+
+DAY_NAMES = {1: "Monday", 2: "Tuesday", 3: "Wednesday", 4: "Thursday", 5: "Friday", 6: "Saturday", 7: "Sunday"}
+
+
+def _format_schedule(auto_schedule: dict, schedules_parsed: list) -> tuple[str | None, dict]:
+    """Build a human-readable schedule summary."""
+    days = auto_schedule.get("days", [])
+    if not days:
+        return None, {}
+
+    active_preset = None
+    from .climate import _normalize_schedule_days
+    current_norm = _normalize_schedule_days(days)
+    for sched in schedules_parsed:
+        if _normalize_schedule_days(sched.get("days", [])) == current_norm:
+            active_preset = sched.get("name")
+            break
+
+    schedule_attrs = {}
+    for day_entry in sorted(days, key=lambda d: d.get("day", 0)):
+        day_num = day_entry.get("day", 0)
+        day_name = DAY_NAMES.get(day_num, f"Day {day_num}")
+        set_points = sorted(
+            day_entry.get("setPoints", []),
+            key=lambda sp: (sp.get("hour", 0), sp.get("minute", 0))
+        )
+
+        blocks = []
+        for i, sp in enumerate(set_points):
+            hour = sp.get("hour", 0)
+            minute = sp.get("minute", 0)
+            temp = sp.get("setPoint", 0) / 10
+
+            start = f"{hour:02d}:{minute:02d}"
+            if i + 1 < len(set_points):
+                next_sp = set_points[i + 1]
+                end = f"{next_sp.get('hour', 0):02d}:{next_sp.get('minute', 0):02d}"
+            else:
+                end = "24:00"
+            blocks.append(f"{start}-{end}: {temp}°C")
+
+        schedule_attrs[day_name] = blocks
+
+    return active_preset, schedule_attrs
+
+
+class FinderBlissScheduleSensor(CoordinatorEntity, SensorEntity):
+    """Sensor showing the active schedule with per-day time blocks."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Schedule"
+
+    def __init__(self, coordinator: DataUpdateCoordinator, device: BlissDevice):
+        super().__init__(coordinator)
+        self._device_serial = getattr(device, "serial_number", getattr(device, "name", None))
+        self._attr_unique_id = f"finderbliss_{self._device_serial}_schedule"
+
+    def _find_device(self) -> BlissDevice | None:
+        for d in self.coordinator.data:
+            if getattr(d, "serial_number", getattr(d, "name", None)) == self._device_serial:
+                return d
+        return None
+
+    @property
+    def native_value(self) -> str | None:
+        dev = self._find_device()
+        if not dev:
+            return None
+        auto_schedule = getattr(dev, "automatic_schedule", {})
+        schedules_parsed = getattr(dev, "schedules_parsed", [])
+        preset_name, _ = _format_schedule(auto_schedule, schedules_parsed)
+        return preset_name or "Custom"
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        dev = self._find_device()
+        if not dev:
+            return {}
+        auto_schedule = getattr(dev, "automatic_schedule", {})
+        schedules_parsed = getattr(dev, "schedules_parsed", [])
+        _, schedule_attrs = _format_schedule(auto_schedule, schedules_parsed)
+        attrs = dict(schedule_attrs)
+        preset_names = [s.get("name") for s in schedules_parsed if s.get("name")]
+        if preset_names:
+            attrs["available_presets"] = preset_names
+        return attrs
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        dev = self._find_device()
+        serial = getattr(dev, "serial_number", self._device_serial) if dev else self._device_serial
+        return DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=getattr(dev, "name", self._device_serial) if dev else self._device_serial,
+            manufacturer="Finder",
+            model=getattr(dev, "model", None) if dev else None,
+        )

--- a/custom_components/finderblissha/strings.json
+++ b/custom_components/finderblissha/strings.json
@@ -1,0 +1,59 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Finder Bliss Login",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      },
+      "reconfigure": {
+        "title": "Update Credentials",
+        "description": "Enter new credentials for your Finder Bliss account.",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate",
+        "description": "Your Finder Bliss credentials are no longer valid. Please enter updated credentials.",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to Finder Bliss cloud",
+      "invalid_auth": "Invalid username or password",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "This account is already configured",
+      "reauth_successful": "Credentials updated successfully",
+      "reconfigure_successful": "Credentials updated successfully"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": { "name": "Temperature" },
+      "humidity": { "name": "Humidity" },
+      "battery": { "name": "Battery" },
+      "wifi_level": { "name": "WiFi level" },
+      "mode": { "name": "Mode" },
+      "manual_set_point": { "name": "Manual set point" },
+      "set_point": { "name": "Set point" },
+      "season": { "name": "Season" },
+      "thermal_differential": { "name": "Thermal differential" },
+      "schedule": { "name": "Schedule" }
+    },
+    "climate": {
+      "thermostat": { "name": "Thermostat" }
+    },
+    "select": {
+      "sync_profile": { "name": "Sync profile" }
+    }
+  }
+}


### PR DESCRIPTION
First of all, thank you @marli1w for the huge amount of work that went into this refactor.

I have tested these changes on a real Finder BLISS1/BLISS2 installation and the results have been excellent. HVAC control is now working correctly, setpoint and mode changes are reliable, and the async behavior appears significantly more stable than previous versions.

This contribution represents one of the most substantial improvements made to the integration so far. To allow further testing and discussion, I am opening this pull request from the contributor's fork into the project's beta branch.
…HomeKit

- BLISS1 manual mode: mode stays "AUTO" with manualSchedule timed override (matching iOS Finder Bliss app behavior), local timezone timestamps
- Use server-provided syncVersion in device payload (not hardcoded 0)
- Use tracked clientSyncVersion in get_devices SyncRequest
- Resync after WebSocket reconnect to get valid sync version
- Fix send_operation: remove internal get_devices that reset pending commands
- Remove pre-command coordinator refresh to avoid competing SyncRequests
- Serialize concurrent Apple Home commands with asyncio.Lock
- Season + mode change in single locked block (no intermediate refresh)
- Fix BLISS1 mode detection: AUTO+isOn=manual, AUTO+!isOn=auto, OFF=off
- Fix set_point: read from settings in manual mode, measures in auto mode
- Schedule presets via climate preset_mode
- Select entity for sync interval profile (Energy saving/Normal/Fast/Super fast)
- Last sync diagnostic sensor with timezone-aware timestamps
- Reconfigure + reauth config flows for credential updates
- HA compliance: DeviceInfo, has_entity_name, entity_category, state_class
- Replace print() with structured logging throughout