### PR TITLE
Fix TypeError in schedule sensor when setPoint is dict-shaped

### DIFF
--- a/custom_components/finderblissha/sensor.py
+++ b/custom_components/finderblissha/sensor.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN
+from .pyfinderbliss.device_parser import parse_set_point
 from .pyfinderbliss.pyfinderbliss_wrapper import BlissDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -269,7 +270,7 @@ def _format_schedule(auto_schedule: dict, schedules_parsed: list) -> tuple[str |
         for i, sp in enumerate(set_points):
             hour = sp.get("hour", 0)
             minute = sp.get("minute", 0)
-            temp = sp.get("setPoint", 0) / 10
+            temp = parse_set_point(sp.get("setPoint"))
 
             start = f"{hour:02d}:{minute:02d}"
             if i + 1 < len(set_points):


### PR DESCRIPTION
The Bliss API sometimes returns `setPoint` inside schedule days as a
dict {"value": N, ...} rather than a plain int. `_format_schedule`
in `sensor.py` did `sp.get("setPoint", 0) / 10` directly, raising:

    TypeError: unsupported operand type(s) for /: 'dict' and 'int'
      File ".../sensor.py", line 272, in _format_schedule
        temp = sp.get("setPoint", 0) / 10

on every coordinator refresh. This left `sensor.*_schedule` in an
error state and spammed the log.

Fix: use the existing `parse_set_point` helper (already used elsewhere
in `device_parser.py`), which handles both dict and numeric shapes and
divides by 10. Two-line change, no behaviour change for numeric inputs.