### PR TITLE
Improve connection resilience, align OFF temperature behavior with mobile app, allow removing stale thermostat

### DIFF
--- a/custom_components/finderblissha/__init__.py
+++ b/custom_components/finderblissha/__init__.py
@@ -8,6 +8,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.config_entries import ConfigEntry
 
 from .const import DOMAIN, PLATFORMS, DEFAULT_SCAN_INTERVAL
@@ -71,3 +72,29 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.data.pop(DOMAIN)
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Allow deleting a device from the UI only if it is no longer on the account.
+
+    Thermostats still reported by the API are managed by the integration and
+    must not be removed by hand (they would just reappear). A device whose
+    serial is no longer returned (e.g. a thermostat replaced or renamed
+    upstream, leaving a stale entry behind) can be deleted.
+    """
+    known_serials: set[str] = set()
+    entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
+    if entry_data and (coordinator := entry_data.get("coordinator")) and coordinator.data:
+        for device in coordinator.data:
+            serial = getattr(device, "serial_number", None) or getattr(device, "name", None)
+            if serial is not None:
+                known_serials.add(str(serial))
+
+    # Removable when none of this device's identifiers map to a live thermostat.
+    return not any(
+        str(identifier[1]) in known_serials
+        for identifier in device_entry.identifiers
+        if identifier[0] == DOMAIN
+    )

--- a/custom_components/finderblissha/climate.py
+++ b/custom_components/finderblissha/climate.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import zoneinfo
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -44,6 +46,53 @@ def _normalize_schedule_days(days: list) -> list:
             ]
         })
     return normalized
+
+
+def _scheduled_set_point(days: list, tz_name: str | None) -> float | None:
+    """Return the set point the schedule calls for right now, in C.
+
+    Day numbering is 1=Monday..7=Sunday, matching isoweekday(). The active
+    block is the last set point at or before now; before the first block of
+    the day it carries over from the most recent earlier day, wrapping the
+    week.
+    """
+    if not days:
+        return None
+
+    by_day: dict[int, list] = {}
+    for day_entry in days:
+        day_num = day_entry.get("day")
+        if day_num is None:
+            continue
+        by_day[day_num] = sorted(
+            day_entry.get("setPoints", []),
+            key=lambda sp: (sp.get("hour", 0), sp.get("minute", 0))
+        )
+    if not by_day:
+        return None
+
+    try:
+        tz = zoneinfo.ZoneInfo(tz_name) if tz_name else None
+    except (zoneinfo.ZoneInfoNotFoundError, ValueError):
+        tz = None
+    now = datetime.now(tz)
+
+    day = now.isoweekday()
+    minutes_now = now.hour * 60 + now.minute
+    for offset in range(7):
+        set_points = by_day.get(day, [])
+        if offset == 0:
+            set_points = [
+                sp for sp in set_points
+                if sp.get("hour", 0) * 60 + sp.get("minute", 0) <= minutes_now
+            ]
+        if set_points:
+            value = set_points[-1].get("setPoint")
+            if isinstance(value, (int, float)):
+                return value / 10
+        day = day - 1 or 7
+
+    return None
 
 
 async def async_setup_entry(
@@ -137,6 +186,19 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
             # Match Finder mobile app logic while OFF:
             # winter -> 5 C, summer -> 35 C.
             return self._attr_max_temp if self._get_season() == "SUMMER" else self._attr_min_temp
+
+        # In schedule mode the device-reported set point lags: it is what the
+        # thermostat last uploaded, so it keeps showing the frost point for a
+        # few sync cycles after leaving OFF, and every schedule step lands late.
+        # Resolve the schedule locally instead, as the mobile app does.
+        if str(getattr(dev, "mode", "")).lower() == "auto":
+            scheduled = _scheduled_set_point(
+                getattr(dev, "automatic_schedule", {}).get("days", []),
+                getattr(dev, "timezone", None),
+            )
+            if scheduled is not None:
+                return scheduled
+
         set_point_raw = getattr(dev, "set_point", None)
         if set_point_raw is None or str(set_point_raw).upper() == "N/A":
             return None

--- a/custom_components/finderblissha/climate.py
+++ b/custom_components/finderblissha/climate.py
@@ -134,7 +134,9 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
         if dev is None:
             return None
         if self.hvac_mode == HVACMode.OFF:
-            return None
+            # Match Finder mobile app logic while OFF:
+            # winter -> 5 C, summer -> 35 C.
+            return self._attr_max_temp if self._get_season() == "SUMMER" else self._attr_min_temp
         set_point_raw = getattr(dev, "set_point", None)
         if set_point_raw is None or str(set_point_raw).upper() == "N/A":
             return None

--- a/custom_components/finderblissha/climate.py
+++ b/custom_components/finderblissha/climate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import zoneinfo
 from datetime import datetime
 from typing import Any
@@ -17,6 +18,7 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -25,27 +27,15 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN
+from .pyfinderbliss.device_parser import normalize_schedule_days
 from .pyfinderbliss.pyfinderbliss_wrapper import BlissDevice, PyFinderBlissAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-
-def _normalize_schedule_days(days: list) -> list:
-    """Normalize schedule days for reliable comparison."""
-    normalized = []
-    for day_entry in sorted(days, key=lambda d: d.get("day", 0)):
-        set_points = sorted(
-            day_entry.get("setPoints", []),
-            key=lambda sp: (sp.get("hour", 0), sp.get("minute", 0))
-        )
-        normalized.append({
-            "day": day_entry.get("day"),
-            "setPoints": [
-                {"hour": sp.get("hour"), "minute": sp.get("minute"), "setPoint": sp.get("setPoint")}
-                for sp in set_points
-            ]
-        })
-    return normalized
+# Ceiling on how long a commanded value stays visible without confirmation.
+# Commands confirm and clear it themselves; this only bounds the damage if the
+# task running one is cancelled before it can.
+OPTIMISTIC_TIMEOUT = 90
 
 
 def _scheduled_set_point(days: list, tz_name: str | None) -> float | None:
@@ -144,6 +134,8 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
         self._device_serial = getattr(device, "serial_number", getattr(device, "name", None))
         self._attr_unique_id = f"finderbliss_climate_{self._device_serial}"
         self._command_lock = asyncio.Lock()
+        # Device attribute -> (commanded value, expiry). See _device_value.
+        self._optimistic: dict[str, tuple[Any, float]] = {}
 
     @property
     def supported_features(self) -> ClimateEntityFeature:
@@ -165,9 +157,42 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
                 return d
         return None
 
-    def _get_season(self) -> str:
+    def _device_value(self, name: str, default: Any = None) -> Any:
+        """Read a device attribute, preferring a command still in flight.
+
+        Every coordinator refresh rebuilds the BlissDevice objects from
+        scratch, so a value written onto them optimistically is gone at the
+        next poll. Held on the entity instead, the commanded value stays put
+        until the command confirms or fails - so a slow write never surfaces
+        as a state change looking like somebody turned the zone back on.
+        """
+        pending = self._optimistic.get(name)
+        if pending is not None:
+            value, expires = pending
+            if time.monotonic() < expires:
+                return value
+            del self._optimistic[name]
+
         dev = self._find_device()
-        return getattr(dev, "season", "WINTER") if dev else "WINTER"
+        if dev is None:
+            return default
+        value = getattr(dev, name, default)
+        return default if value is None else value
+
+    def _set_optimistic(self, values: dict[str, Any] | None) -> None:
+        if not values:
+            return
+        expires = time.monotonic() + OPTIMISTIC_TIMEOUT
+        for key, value in values.items():
+            self._optimistic[key] = (value, expires)
+        self.async_write_ha_state()
+
+    def _clear_optimistic(self, values: dict[str, Any] | None) -> None:
+        for key in values or {}:
+            self._optimistic.pop(key, None)
+
+    def _get_season(self) -> str:
+        return self._device_value("season", "WINTER")
 
     # --- Properties ---
 
@@ -191,15 +216,15 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
         # thermostat last uploaded, so it keeps showing the frost point for a
         # few sync cycles after leaving OFF, and every schedule step lands late.
         # Resolve the schedule locally instead, as the mobile app does.
-        if str(getattr(dev, "mode", "")).lower() == "auto":
+        if str(self._device_value("mode", "")).lower() == "auto":
             scheduled = _scheduled_set_point(
-                getattr(dev, "automatic_schedule", {}).get("days", []),
+                self._device_value("automatic_schedule", {}).get("days", []),
                 getattr(dev, "timezone", None),
             )
             if scheduled is not None:
                 return scheduled
 
-        set_point_raw = getattr(dev, "set_point", None)
+        set_point_raw = self._device_value("set_point")
         if set_point_raw is None or str(set_point_raw).upper() == "N/A":
             return None
         try:
@@ -209,11 +234,8 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def hvac_mode(self) -> HVACMode:
-        dev = self._find_device()
-        if dev is None:
-            return HVACMode.OFF
-        mode = getattr(dev, "mode", "off")
-        if mode == "off":
+        mode = self._device_value("mode")
+        if mode is None or str(mode).lower() == "off":
             return HVACMode.OFF
         # Both "auto" and "manual" resolve to HEAT/COOL based on season
         season = self._get_season()
@@ -246,16 +268,15 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
         dev = self._find_device()
         if dev is None:
             return None
-        mode = getattr(dev, "mode", "off")
-        if mode != "auto":
+        if str(self._device_value("mode", "")).lower() != "auto":
             return None
 
         schedules = getattr(dev, "schedules_parsed", [])
-        current_auto = getattr(dev, "automatic_schedule", {})
+        current_auto = self._device_value("automatic_schedule", {})
         if schedules and current_auto:
-            current_days = _normalize_schedule_days(current_auto.get("days", []))
+            current_days = normalize_schedule_days(current_auto.get("days", []))
             for sched in schedules:
-                preset_days = _normalize_schedule_days(sched.get("days", []))
+                preset_days = normalize_schedule_days(sched.get("days", []))
                 if current_days == preset_days:
                     return sched.get("name")
         return None
@@ -277,29 +298,46 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
         if not dev:
             return {}
         return {
-            "season": getattr(dev, "season", None),
-            "operating_mode": getattr(dev, "mode", None),
+            "season": self._device_value("season"),
+            "operating_mode": self._device_value("mode"),
         }
 
     # --- Control Methods ---
 
-    async def _async_execute_api_command(self, api_coroutine, *args, **kwargs) -> None:
-        """Execute an API command and update HA state optimistically.
-
-        Serialized with a lock so concurrent commands from Apple Home
-        (e.g. HVAC mode + temperature at the same time) don't race.
-
-        The wrapper methods (set_mode, set_setpoint, etc.) update the
-        BlissDevice attributes in-place.  These are the same objects in
-        coordinator.data, so the entity properties immediately reflect
-        the new values.  We push that state to HA right away instead of
-        triggering a coordinator refresh, which would send a SyncRequest
-        over the same WebSocket and risk reading stale buffered messages.
-        The regular polling interval syncs the full state from the server.
-        """
+    async def _async_execute_api_command(self, api_coroutine, *args, optimistic=None, **kwargs) -> None:
+        """Execute an API command, serialized against other commands on this entity."""
         async with self._command_lock:
-            await api_coroutine(*args, **kwargs)
-        self.async_write_ha_state()
+            await self._async_command(api_coroutine, *args, optimistic=optimistic, **kwargs)
+
+    async def _async_command(self, api_coroutine, *args, optimistic=None, **kwargs) -> None:
+        """Run one command with the entity lock already held.
+
+        The commanded value goes up straight away so Apple Home reacts at once,
+        but it is the API layer that decides whether the command counts: it
+        returns only once the server has been read back and agrees. That
+        verified snapshot is pushed into the coordinator instead of waiting up
+        to a poll interval for the same news.
+
+        On failure the commanded value is dropped and the error raised. A
+        command the server silently declined must not read as applied - that is
+        what makes a lost write show up minutes later as a phantom manual
+        change.
+        """
+        self._set_optimistic(optimistic)
+        try:
+            devices = await api_coroutine(*args, **kwargs)
+        except Exception as err:
+            self._clear_optimistic(optimistic)
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                f"Finder Bliss command failed for {self._device_serial}: {err}"
+            ) from err
+
+        self._clear_optimistic(optimistic)
+        if devices:
+            self.coordinator.async_set_updated_data(devices)
+        else:
+            self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set HVAC mode.
@@ -311,31 +349,34 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
         """
         if hvac_mode == HVACMode.OFF:
             await self._async_execute_api_command(
-                self._api.async_set_mode, self._device_serial, "OFF"
+                self._api.async_set_mode, self._device_serial, "OFF",
+                optimistic={"mode": "off"},
             )
             return
 
         if hvac_mode == HVACMode.AUTO:
             # Resume schedule — after refresh, hvac_mode resolves to HEAT/COOL
             await self._async_execute_api_command(
-                self._api.async_set_mode, self._device_serial, "AUTO"
+                self._api.async_set_mode, self._device_serial, "AUTO",
+                optimistic={"mode": "auto"},
             )
             return
 
-        # HEAT or COOL → set season (if needed) + manual mode
-        # Both commands run inside one lock acquisition so no intermediate
-        # coordinator refresh can replace the device objects between them.
-        dev = self._find_device()
-        current_season = getattr(dev, "season", "WINTER") if dev else "WINTER"
+        # HEAT or COOL → set season (if needed) + manual mode.
+        # Both commands run inside one lock acquisition so a second command on
+        # this entity cannot land between them.
+        season = "SUMMER" if hvac_mode == HVACMode.COOL else "WINTER"
 
         async with self._command_lock:
-            if hvac_mode == HVACMode.COOL and current_season != "SUMMER":
-                await self._api.async_set_season(self._device_serial, "SUMMER")
-            elif hvac_mode == HVACMode.HEAT and current_season != "WINTER":
-                await self._api.async_set_season(self._device_serial, "WINTER")
-
-            await self._api.async_set_mode(self._device_serial, "MANUAL")
-        self.async_write_ha_state()
+            if self._get_season() != season:
+                await self._async_command(
+                    self._api.async_set_season, self._device_serial, season,
+                    optimistic={"season": season},
+                )
+            await self._async_command(
+                self._api.async_set_mode, self._device_serial, "MANUAL",
+                optimistic={"mode": "manual"},
+            )
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         target_temp = kwargs.get(ATTR_TEMPERATURE)
@@ -349,14 +390,23 @@ class FinderBlissClimate(CoordinatorEntity, ClimateEntity):
             await self.async_set_hvac_mode(target_hvac)
 
         await self._async_execute_api_command(
-            self._api.async_set_temperature, self._device_serial, target_temp
+            self._api.async_set_temperature, self._device_serial, target_temp,
+            optimistic={"set_point": target_temp, "mode": "manual"},
         )
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Apply a named schedule and switch to auto mode."""
+        dev = self._find_device()
+        schedule = next(
+            (s for s in getattr(dev, "schedules_parsed", []) if s.get("name") == preset_mode),
+            None,
+        ) if dev else None
+
         await self._async_execute_api_command(
-            self._api.async_set_schedule_preset, self._device_serial, preset_mode
+            self._api.async_set_schedule_preset, self._device_serial, preset_mode,
+            optimistic={"automatic_schedule": {"days": schedule["days"]}} if schedule else None,
         )
         await self._async_execute_api_command(
-            self._api.async_set_mode, self._device_serial, "AUTO"
+            self._api.async_set_mode, self._device_serial, "AUTO",
+            optimistic={"mode": "auto"},
         )

--- a/custom_components/finderblissha/manifest.json
+++ b/custom_components/finderblissha/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "finderblissha",
   "name": "Finder Bliss Thermostats",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "documentation": "https://github.com/condatek/finderblissha",
   "issue_tracker": "https://github.com/condatek/finderblissha/issues",
   "requirements": [],

--- a/custom_components/finderblissha/pyfinderbliss/client.py
+++ b/custom_components/finderblissha/pyfinderbliss/client.py
@@ -44,8 +44,16 @@ class BlissClientAsync:
     async def close(self):
         if self._ws and not self._ws.closed:
             await self._ws.close()
+        self._ws = None
         if self._session and not self._session.closed:
             await self._session.close()
+        self._session = None
+
+    async def reset_connection(self):
+        """Reset only the websocket so the next operation reconnects cleanly."""
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
 
     def _get_stamp(self):
         return datetime.datetime.now(datetime.timezone.utc).isoformat(
@@ -149,10 +157,7 @@ class BlissClientAsync:
             except asyncio.TimeoutError:
                 raise Exception("Timeout waiting for InitRequest acknowledgment.")
 
-    async def get_devices(self, ws_timeout: int = 15):
-        if not self._ws or self._ws.closed:
-            await self.connect_ws()
-
+    async def get_devices(self, ws_timeout: int = 15, reconnect_attempts: int = 2):
         sync_request = {
             "type": 1,
             "target": "SyncRequest",
@@ -172,29 +177,45 @@ class BlissClientAsync:
             ],
         }
 
-        await self._ws.send_str(json.dumps(sync_request) + "\x1e")
+        last_error: Exception | None = None
+        for attempt in range(reconnect_attempts + 1):
+            if not self._ws or self._ws.closed:
+                await self.connect_ws()
 
-        try:
-            while True:
-                msg = await asyncio.wait_for(self._ws.receive(), timeout=ws_timeout)
-                frames = await self._handle_message(msg)
+            try:
+                await self._ws.send_str(json.dumps(sync_request) + "\x1e")
 
-                for data in frames:
-                    if data.get("target") in ("SyncRequest", "SyncResponse") and "arguments" in data:
-                        for arg in data["arguments"]:
-                            if "serverPayload" in arg and arg["serverPayload"] is not None:
-                                self._last_server_sync_version = arg.get("serverSyncVersion", 0)
-                                _LOGGER.debug(
-                                    "Sync success, serverSyncVersion: %s",
-                                    self._last_server_sync_version,
-                                )
-                                payload = arg["serverPayload"]
-                                return parse_device_data(payload)
+                while True:
+                    msg = await asyncio.wait_for(self._ws.receive(), timeout=ws_timeout)
+                    frames = await self._handle_message(msg)
 
-        except asyncio.TimeoutError:
-            raise Exception(f"Timeout waiting for serverPayload after {ws_timeout} seconds.")
-        except ConnectionResetError:
-            raise Exception("Connection reset by server during device fetch.")
+                    for data in frames:
+                        if data.get("target") in ("SyncRequest", "SyncResponse") and "arguments" in data:
+                            for arg in data["arguments"]:
+                                if "serverPayload" in arg and arg["serverPayload"] is not None:
+                                    self._last_server_sync_version = arg.get("serverSyncVersion", 0)
+                                    _LOGGER.debug(
+                                        "Sync success, serverSyncVersion: %s",
+                                        self._last_server_sync_version,
+                                    )
+                                    payload = arg["serverPayload"]
+                                    return parse_device_data(payload)
+
+            except (asyncio.TimeoutError, ConnectionResetError, aiohttp.ClientError) as err:
+                last_error = err
+                _LOGGER.warning(
+                    "Device sync attempt %s/%s failed: %s. Resetting websocket and retrying.",
+                    attempt + 1,
+                    reconnect_attempts + 1,
+                    err,
+                )
+                await self.reset_connection()
+
+        if isinstance(last_error, asyncio.TimeoutError):
+            raise Exception(f"Timeout waiting for serverPayload after {ws_timeout} seconds.") from last_error
+        if isinstance(last_error, ConnectionResetError):
+            raise Exception("Connection reset by server during device fetch.") from last_error
+        raise Exception(f"Failed to fetch devices after websocket reconnect attempts: {last_error}")
 
     async def send_operation(self, device_data: dict, operation_key: str = "ALL", debug_responses: int = 3):
         if not self._ws or self._ws.closed:

--- a/custom_components/finderblissha/pyfinderbliss/client.py
+++ b/custom_components/finderblissha/pyfinderbliss/client.py
@@ -22,6 +22,10 @@ from .device_parser import parse_device_data
 _LOGGER = logging.getLogger(__name__)
 
 
+class BlissCommandError(Exception):
+    """A command was not acknowledged, or not applied, by the Finder cloud."""
+
+
 class BlissClientAsync:
     """Asynchronous client for the Finder Bliss API."""
 
@@ -300,15 +304,21 @@ class BlissClientAsync:
             except ConnectionResetError:
                 raise Exception("Connection reset by server during command acknowledgement.")
 
-        if not new_version_received:
-            _LOGGER.warning("No ACK received from server after command")
-
         # Drain any follow-up messages the server sends after the ACK
         # (e.g. updated device data). If left in the buffer, the next
         # get_devices() call would pick them up as a partial response.
+        # Runs on the un-acknowledged path too, so a failed command still
+        # leaves a clean buffer for the retry.
         try:
             while True:
                 msg = await asyncio.wait_for(self._ws.receive(), timeout=1)
                 await self._handle_message(msg)
         except asyncio.TimeoutError:
             pass
+
+        # An un-acknowledged command is a dropped one. Returning normally here
+        # would report success for a write the server never took, which then
+        # surfaces a poll or two later as the old value coming back - looking
+        # exactly like somebody changed it by hand.
+        if not new_version_received:
+            raise BlissCommandError("Server did not acknowledge the command")

--- a/custom_components/finderblissha/pyfinderbliss/client.py
+++ b/custom_components/finderblissha/pyfinderbliss/client.py
@@ -34,6 +34,13 @@ class BlissClientAsync:
         self._ws = None
         self._last_server_sync_version = 0
         self._debug = debug
+        # A single websocket serves every device, so two callers arriving
+        # together - a service call targeting two thermostats fans out to both
+        # entities in parallel - would both sit in ws.receive() and aiohttp
+        # raises "Concurrent call to receive() is not allowed". Every exchange
+        # is serialised through this lock; the _-prefixed variants below are
+        # the bodies that run with it already held.
+        self._ws_lock = asyncio.Lock()
 
     async def _ensure_session(self):
         if self._session is None or self._session.closed:
@@ -51,6 +58,10 @@ class BlissClientAsync:
 
     async def reset_connection(self):
         """Reset only the websocket so the next operation reconnects cleanly."""
+        async with self._ws_lock:
+            await self._reset_connection()
+
+    async def _reset_connection(self):
         if self._ws and not self._ws.closed:
             await self._ws.close()
         self._ws = None
@@ -158,6 +169,10 @@ class BlissClientAsync:
                 raise Exception("Timeout waiting for InitRequest acknowledgment.")
 
     async def get_devices(self, ws_timeout: int = 15, reconnect_attempts: int = 2):
+        async with self._ws_lock:
+            return await self._get_devices(ws_timeout, reconnect_attempts)
+
+    async def _get_devices(self, ws_timeout: int = 15, reconnect_attempts: int = 2):
         sync_request = {
             "type": 1,
             "target": "SyncRequest",
@@ -209,7 +224,7 @@ class BlissClientAsync:
                     reconnect_attempts + 1,
                     err,
                 )
-                await self.reset_connection()
+                await self._reset_connection()
 
         if isinstance(last_error, asyncio.TimeoutError):
             raise Exception(f"Timeout waiting for serverPayload after {ws_timeout} seconds.") from last_error
@@ -218,11 +233,15 @@ class BlissClientAsync:
         raise Exception(f"Failed to fetch devices after websocket reconnect attempts: {last_error}")
 
     async def send_operation(self, device_data: dict, operation_key: str = "ALL", debug_responses: int = 3):
+        async with self._ws_lock:
+            await self._send_operation(device_data, operation_key, debug_responses)
+
+    async def _send_operation(self, device_data: dict, operation_key: str = "ALL", debug_responses: int = 3):
         if not self._ws or self._ws.closed:
             _LOGGER.debug("WebSocket closed before send_operation, reconnecting")
             await self.connect_ws()
             # Resync to get a valid _last_server_sync_version for the new session
-            await self.get_devices(ws_timeout=10)
+            await self._get_devices(ws_timeout=10)
 
         payload_to_send = dict(device_data)
 

--- a/custom_components/finderblissha/pyfinderbliss/device_parser.py
+++ b/custom_components/finderblissha/pyfinderbliss/device_parser.py
@@ -38,14 +38,38 @@ def determine_bliss1_mode(settings: dict) -> str:
 
 
 def determine_bliss2_mode(measures: dict) -> str:
-    """Determine operating mode for BLISS2 devices."""
+    """Determine operating mode for BLISS2 devices.
+
+    Lower case to match determine_bliss1_mode: consumers compare against
+    "off"/"auto"/"manual", and the setters write the same lower-case values
+    back onto the device, so a BLISS2 reporting "OFF" here never matched and
+    flipped case on every command.
+    """
     mode = measures.get("mode", 0)
     return {
-        0: "OFF",
-        1: "AUTO",
-        2: "OFF",
-        3: "MANUAL"
-    }.get(mode, "UNKNOWN")
+        0: "off",
+        1: "auto",
+        2: "off",
+        3: "manual"
+    }.get(mode, "unknown")
+
+
+def normalize_schedule_days(days: list) -> list:
+    """Normalize schedule days for reliable comparison."""
+    normalized = []
+    for day_entry in sorted(days or [], key=lambda d: d.get("day", 0)):
+        set_points = sorted(
+            day_entry.get("setPoints", []),
+            key=lambda sp: (sp.get("hour", 0), sp.get("minute", 0))
+        )
+        normalized.append({
+            "day": day_entry.get("day"),
+            "setPoints": [
+                {"hour": sp.get("hour"), "minute": sp.get("minute"), "setPoint": sp.get("setPoint")}
+                for sp in set_points
+            ]
+        })
+    return normalized
 
 
 
@@ -102,7 +126,7 @@ def parse_device(device: dict) -> dict:
         else:
             set_point = parse_set_point(measures_parsed.get("loggerSetPoint"))
     else:
-        if mode == "MANUAL":
+        if mode == "manual":
             set_point = parse_set_point(
                 settings_parsed.get("primary", {}).get("manualSetPoint")
             )

--- a/custom_components/finderblissha/pyfinderbliss/pyfinderbliss_wrapper.py
+++ b/custom_components/finderblissha/pyfinderbliss/pyfinderbliss_wrapper.py
@@ -274,6 +274,10 @@ class PyFinderBlissAPI:
                 print(f"[FinderBliss] Device fetch failed (attempt {attempt+1}): {e}")
 
                 if attempt < self._max_retries - 1:
+                    try:
+                        await self._client.reset_connection()
+                    except Exception:
+                        pass
                     await self._async_ensure_authenticated()
                     await asyncio.sleep(self._retry_delay)
                     continue

--- a/custom_components/finderblissha/pyfinderbliss/pyfinderbliss_wrapper.py
+++ b/custom_components/finderblissha/pyfinderbliss/pyfinderbliss_wrapper.py
@@ -1,7 +1,55 @@
 import asyncio
 import json
+import logging
+import time
 from typing import Union
-from .client import BlissClientAsync
+from .client import BlissClientAsync, BlissCommandError
+from .device_parser import normalize_schedule_days
+
+_LOGGER = logging.getLogger(__name__)
+
+# A command is re-read from the server before it is reported as applied.
+COMMAND_ATTEMPTS = 2
+# The ACK means the frame was accepted, not that the new settings are queryable.
+COMMAND_VERIFY_DELAY = 1.5
+COMMAND_RETRY_DELAY = 3.0
+# How long a polled snapshot stays usable as the base for a command payload.
+SNAPSHOT_TTL = 15.0
+
+# What each command string should look like once the server has taken it.
+_EXPECTED_MODE = {
+    "OFF": "off",
+    "FROST": "off",
+    "AUTO": "auto",
+    "MANUAL": "manual",
+    "ECO": "eco",
+}
+
+
+def commanded_mode(device: 'BlissDevice') -> str | None:
+    """The mode the server has been told to hold.
+
+    Not the same question as `device.mode` on a BLISS2, where the mode is read
+    from `measures` - the thermostat's own echo, which only moves when it next
+    checks in, minutes later. Verifying a write against that would time out on
+    every command, so read the commanded setting instead. BLISS1 already
+    derives `mode` from `settings`, which is the commanded side.
+    """
+    if getattr(device, "tag", None) == "BLISS1":
+        return getattr(device, "mode", None)
+    setting = str(getattr(device, "mode_setting", "") or "").lower()
+    if not setting or setting == "n/a":
+        return None
+    return "off" if setting == "frost" else setting
+
+
+def _set_point_matches(reported, expected) -> bool:
+    """Compare set points that round-trip through tenths of a degree."""
+    try:
+        return abs(float(reported) - float(expected)) < 0.05
+    except (TypeError, ValueError):
+        return False
+
 
 class BlissDevice:
     def __init__(self, device_data):
@@ -223,6 +271,12 @@ class PyFinderBlissAPI:
         self._devices = []
         self._max_retries = max_retries
         self._retry_delay = retry_delay
+        # One command at a time per account: each one re-reads the snapshot it
+        # builds its payload from, and two commands interleaving would hand the
+        # second a snapshot the first has already superseded.
+        self._command_lock = asyncio.Lock()
+        self._snapshot_ts = 0.0
+        self._snapshot_dirty = True
 
     async def _async_ensure_authenticated(self):
         if hasattr(self._client, "is_logged_in") and self._client.is_logged_in:
@@ -263,15 +317,21 @@ class PyFinderBlissAPI:
         for attempt in range(self._max_retries):
             try:
                 devices_data = await self._client.get_devices()
-                self._devices = [BlissDevice(d) for d in devices_data]
+                devices = [BlissDevice(d) for d in devices_data]
 
-                for dev in self._devices:
+                for dev in devices:
                     dev._client = self._client
 
+                devices, partial = self._merge_known_devices(devices)
+                self._devices = devices
+                self._snapshot_ts = time.monotonic()
+                # Anything carried over still holds an older poll's syncVersion,
+                # so this snapshot must not be the base for the next command.
+                self._snapshot_dirty = partial
                 return self._devices
 
             except Exception as e:
-                print(f"[FinderBliss] Device fetch failed (attempt {attempt+1}): {e}")
+                _LOGGER.warning("Device fetch failed (attempt %s): %s", attempt + 1, e)
 
                 if attempt < self._max_retries - 1:
                     try:
@@ -286,47 +346,158 @@ class PyFinderBlissAPI:
 
         raise Exception("Failed to fetch devices after retries")
 
-    def _find_device_by_serial(self, serial: str) -> Union['BlissDevice', None]:
+    @staticmethod
+    def _device_key(device: 'BlissDevice'):
+        return getattr(device, "serial_number", None) or getattr(device, "name", None)
+
+    def _merge_known_devices(self, devices: list) -> tuple[list, bool]:
+        """Carry over devices the server left out of a partial payload.
+
+        A SyncRequest normally answers with the whole inventory, but the server
+        also pushes deltas naming only the device a command just touched, and
+        one of those arriving out of turn is indistinguishable from a full
+        answer here. Taken at face value the other thermostats look deleted:
+        their entities drop to unknown, and a command aimed at one of them
+        fails with "not found in tracked devices".
+        """
+        known = {self._device_key(d): d for d in self._devices}
+        if not known:
+            return devices, False
+
+        seen = {self._device_key(d) for d in devices}
+        missing = [device for key, device in known.items() if key not in seen]
+        if not missing:
+            return devices, False
+
+        _LOGGER.warning(
+            "Partial device payload: %s of %s devices returned, carrying over %s",
+            len(devices), len(known),
+            ", ".join(str(getattr(d, "name", "?")) for d in missing),
+        )
+        return devices + missing, True
+
+    def _find_device_by_serial(self, serial: str, devices=None) -> Union['BlissDevice', None]:
         return next(
-            (d for d in self._devices
+            (d for d in (self._devices if devices is None else devices)
              if getattr(d, 'serial_number', getattr(d, 'name')) == serial),
             None
         )
 
+    async def _async_fresh_devices(self):
+        """Return a snapshot recent enough to build a command payload from.
+
+        Every payload carries the device's own syncVersion from whichever poll
+        produced it. Sending one built on a superseded snapshot risks the
+        server discarding it as a conflict, which is indistinguishable from
+        success at this layer - so any successful write invalidates the
+        snapshot for the next command.
+        """
+        if self._snapshot_dirty or (time.monotonic() - self._snapshot_ts) > SNAPSHOT_TTL:
+            return await self.async_get_devices()
+        return self._devices
+
+    async def _async_run_command(self, device_serial: str, apply_fn, verify_fn, description: str):
+        """Apply a command and confirm the server took it, retrying if it did not.
+
+        An ACK only proves the frame was accepted; whether the settings landed
+        is a separate question. A lost write is otherwise invisible - the next
+        poll just reports the old value, which downstream reads as somebody
+        having changed it by hand. Returns the snapshot that confirmed it, so
+        the caller can publish state it has actually verified.
+        """
+        async with self._command_lock:
+            last_error: Exception | None = None
+
+            for attempt in range(1, COMMAND_ATTEMPTS + 1):
+                await self._async_ensure_authenticated()
+                devices = await self._async_fresh_devices()
+                device = self._find_device_by_serial(device_serial, devices)
+                if device is None:
+                    raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
+
+                try:
+                    await apply_fn(device)
+                except ValueError:
+                    # A bad argument will not become valid on a retry.
+                    raise
+                except Exception as err:
+                    last_error = err
+                    _LOGGER.warning(
+                        "%s failed on attempt %s/%s: %s",
+                        description, attempt, COMMAND_ATTEMPTS, err,
+                    )
+                else:
+                    self._snapshot_dirty = True
+                    await asyncio.sleep(COMMAND_VERIFY_DELAY)
+                    devices = await self.async_get_devices()
+                    confirmed = self._find_device_by_serial(device_serial, devices)
+                    if confirmed is not None and verify_fn(confirmed):
+                        return devices
+
+                    last_error = BlissCommandError(
+                        f"{description}: the server did not apply the command"
+                    )
+                    _LOGGER.warning(
+                        "%s was not confirmed on attempt %s/%s",
+                        description, attempt, COMMAND_ATTEMPTS,
+                    )
+
+                if attempt < COMMAND_ATTEMPTS:
+                    await asyncio.sleep(COMMAND_RETRY_DELAY)
+
+            raise last_error
+
     async def async_set_temperature(self, device_serial: str, temperature: float):
-        await self._async_ensure_authenticated()
-        device = self._find_device_by_serial(device_serial)
-        if not device:
-            raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
-        await device.set_setpoint(value=temperature)
+        return await self._async_run_command(
+            device_serial,
+            lambda device: device.set_setpoint(value=temperature),
+            lambda device: _set_point_matches(device.manual_set_point, temperature),
+            f"Set point {temperature}",
+        )
 
     async def async_set_mode(self, device_serial: str, mode: str):
-        await self._async_ensure_authenticated()
-        device = self._find_device_by_serial(device_serial)
-        if not device:
-            raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
-        await device.set_mode(mode=mode)
+        expected = _EXPECTED_MODE.get(mode.upper())
+        return await self._async_run_command(
+            device_serial,
+            lambda device: device.set_mode(mode=mode),
+            lambda device: commanded_mode(device) == expected,
+            f"Mode {mode.upper()}",
+        )
 
     async def async_set_season(self, device_serial: str, season: str):
-        await self._async_ensure_authenticated()
-        device = self._find_device_by_serial(device_serial)
-        if not device:
-            raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
-        await device.set_season(season=season)
+        expected = season.upper()
+        return await self._async_run_command(
+            device_serial,
+            lambda device: device.set_season(season=season),
+            lambda device: str(device.season or "").upper() == expected,
+            f"Season {expected}",
+        )
 
     async def async_set_update_step(self, device_serial: str, minutes: int):
-        await self._async_ensure_authenticated()
-        device = self._find_device_by_serial(device_serial)
-        if not device:
-            raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
-        await device.set_update_step(minutes=minutes)
+        return await self._async_run_command(
+            device_serial,
+            lambda device: device.set_update_step(minutes=minutes),
+            lambda device: device.update_step == minutes,
+            f"Sync interval {minutes}",
+        )
 
     async def async_set_schedule_preset(self, device_serial: str, preset_name: str):
-        await self._async_ensure_authenticated()
-        device = self._find_device_by_serial(device_serial)
-        if not device:
-            raise ValueError(f"Device with serial {device_serial} not found in tracked devices.")
-        await device.set_schedule_preset(preset_name=preset_name)
+        def _applied(device: 'BlissDevice') -> bool:
+            target = next(
+                (s for s in device.schedules_parsed if s.get("name") == preset_name),
+                None,
+            )
+            if target is None:
+                return False
+            active = normalize_schedule_days(device.automatic_schedule.get("days", []))
+            return active == normalize_schedule_days(target.get("days", []))
+
+        return await self._async_run_command(
+            device_serial,
+            lambda device: device.set_schedule_preset(preset_name=preset_name),
+            _applied,
+            f"Schedule preset {preset_name!r}",
+        )
 
     async def async_close(self):
         await self._client.close()

--- a/custom_components/finderblissha/select.py
+++ b/custom_components/finderblissha/select.py
@@ -8,6 +8,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -99,5 +100,11 @@ class FinderBlissUpdateProfileSelect(CoordinatorEntity, SelectEntity):
         if level is None:
             _LOGGER.error("Unknown sync profile: %s", option)
             return
-        await self._api.async_set_update_step(self._device_serial, level)
-        await self.coordinator.async_request_refresh()
+        try:
+            devices = await self._api.async_set_update_step(self._device_serial, level)
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Finder Bliss command failed for {self._device_serial}: {err}"
+            ) from err
+        # The API returns the snapshot that confirmed the change.
+        self.coordinator.async_set_updated_data(devices)

--- a/custom_components/finderblissha/sensor.py
+++ b/custom_components/finderblissha/sensor.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN
+from .pyfinderbliss.device_parser import normalize_schedule_days
 from .pyfinderbliss.pyfinderbliss_wrapper import BlissDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -249,10 +250,9 @@ def _format_schedule(auto_schedule: dict, schedules_parsed: list) -> tuple[str |
         return None, {}
 
     active_preset = None
-    from .climate import _normalize_schedule_days
-    current_norm = _normalize_schedule_days(days)
+    current_norm = normalize_schedule_days(days)
     for sched in schedules_parsed:
-        if _normalize_schedule_days(sched.get("days", [])) == current_norm:
+        if normalize_schedule_days(sched.get("days", [])) == current_norm:
             active_preset = sched.get("name")
             break
 


### PR DESCRIPTION
This PR includes three improvements:

- Improved reliability on weak connections by resetting/reconnecting websocket polling, reducing “unavailable” thermostats and manual reloads.
- Fixed OFF target temperature behavior to match Finder app logic: SUMMER shows 35 C (WINTER stays 5 C).
- Added support for removing stale thermostat devices from Home Assistant UI when they are no longer present in the Finder account.
- Added local schedule resolution for set points in auto mode
- Fixed failure on concurrent commands (e.g., from automation) on multiple devices
